### PR TITLE
Converted Agent and Common unit tests to xUnit 2.x using nuget packages

### DIFF
--- a/csharp/unittests/agent/AddressTest.cs
+++ b/csharp/unittests/agent/AddressTest.cs
@@ -11,21 +11,18 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
 using System.Security.Cryptography.X509Certificates;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
     public class AddressTest
     {
-
         [Fact]
         public void TestBasicAddressCreate()
         {
@@ -84,12 +81,11 @@ namespace Health.Direct.Agent.Tests
             Assert.True(coll.Certificates.Count() == 0);
             Assert.True(coll.GetUntrusted().Count() == 0);
             Assert.True(coll.GetTrusted().Count() == 0);
-            Assert.DoesNotThrow(() => coll.RemoveUntrusted());
+            Assert.Null(Record.Exception(() => coll.RemoveUntrusted()));
         }
 
-
         [Theory]
-        [InlineData(null,0)]
+        [InlineData(null, 0)]
         [InlineData("", 0)]
         [InlineData("eleanor@roosevelt.com, \"Franklin Roosevelt\" <frank@roosevelt.com>, sean+o'nolan@tinymollitude.net", 3)]
         public void TestParseAddressCollection(string addressList, int expectedCount)
@@ -110,7 +106,7 @@ namespace Health.Direct.Agent.Tests
         public void TestAddressCollectionIsTrustedAllTrusted()
         {
             DirectAddressCollection coll = BasicCollection();
-            foreach(DirectAddress addr in coll) { addr.Status = TrustEnforcementStatus.Success; }
+            foreach (DirectAddress addr in coll) { addr.Status = TrustEnforcementStatus.Success; }
             //All trusted addresses should be trusted
             Assert.True(coll.IsTrusted());
         }
@@ -122,7 +118,6 @@ namespace Health.Direct.Agent.Tests
             // should be able to define a custom floor for trust
             Assert.True(coll.IsTrusted(TrustEnforcementStatus.Failed));
         }
-
 
         [Fact]
         public void TestAddressCollectionGetTrusted()
@@ -169,11 +164,13 @@ namespace Health.Direct.Agent.Tests
 
         DirectAddressCollection BasicCollection()
         {
-            string[] addrStrings = new string[] {
-                                                    "eleanor@roosevelt.com",
-                                                    "\"Franklin Roosevelt\" <frank@roosevelt.com>",
-                                                    "sean+o'nolan@tinymollitude.net"};
-            IEnumerable<DirectAddress> addrs =  addrStrings.Select(a => new DirectAddress(a));
+            string[] addrStrings = new string[]
+            {
+                "eleanor@roosevelt.com",
+                "\"Franklin Roosevelt\" <frank@roosevelt.com>",
+                "sean+o'nolan@tinymollitude.net"
+            };
+            IEnumerable<DirectAddress> addrs = addrStrings.Select(a => new DirectAddress(a));
             DirectAddressCollection coll = new DirectAddressCollection();
             coll.Add(addrs);
             coll[0].Status = TrustEnforcementStatus.Failed;
@@ -181,6 +178,5 @@ namespace Health.Direct.Agent.Tests
             coll[2].Status = TrustEnforcementStatus.Success;
             return coll;
         }
-
     }
 }

--- a/csharp/unittests/agent/AgentConfigTest.cs
+++ b/csharp/unittests/agent/AgentConfigTest.cs
@@ -12,11 +12,9 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
 
 using Health.Direct.Agent.Config;
-
 using Xunit;
 
 namespace Health.Direct.Agent.Tests
@@ -62,20 +60,20 @@ namespace Health.Direct.Agent.Tests
                 </Trust>
             </AgentSettings>
         ";
-        
+
         static AgentConfigTest()
         {
             AgentTester.EnsureStandardMachineStores();
         }
-        
+
         public AgentConfigTest()
         {
         }
-           
+
         [Fact]
         public void TestConfig()
         {
-            AgentSettings settings = AgentSettings.Load(TestXml);   
+            AgentSettings settings = AgentSettings.Load(TestXml);
             DirectAgent agent = settings.CreateAgent();
         }
     }

--- a/csharp/unittests/agent/AgentTester.cs
+++ b/csharp/unittests/agent/AgentTester.cs
@@ -12,10 +12,9 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mail;
@@ -23,7 +22,6 @@ using System.Security.Cryptography.X509Certificates;
 using Health.Direct.Common;
 using Health.Direct.Common.Certificates;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -34,11 +32,11 @@ namespace Health.Direct.Agent.Tests
     {
         public const string DefaultDomainA = "redmond.hsgincubator.com";
         public const string DefaultDomainB = "nhind.hsgincubator.com";
-        
+
         DirectAgent m_agentA;
         DirectAgent m_agentB;
         string m_messageFolder;
-        
+
         public AgentTester(DirectAgent agentA, DirectAgent agentB)
         {
             if (agentA == null)
@@ -50,12 +48,12 @@ namespace Health.Direct.Agent.Tests
             {
                 throw new ArgumentNullException("agentB");
             }
-            
+
             m_agentA = agentA;
             m_agentB = agentB;
             m_messageFolder = Path.Combine(Directory.GetCurrentDirectory(), "TestMessages");
         }
-        
+
         public DirectAgent AgentA
         {
             get
@@ -67,7 +65,7 @@ namespace Health.Direct.Agent.Tests
                 m_agentA = value;
             }
         }
-        
+
         public DirectAgent AgentB
         {
             get
@@ -79,7 +77,7 @@ namespace Health.Direct.Agent.Tests
                 m_agentB = value;
             }
         }
-        
+
         public string MessageFolder
         {
             get
@@ -92,25 +90,25 @@ namespace Health.Direct.Agent.Tests
                 {
                     throw new ArgumentException("value null or empty", "value");
                 }
-                
+
                 if (!Directory.Exists(value))
                 {
                     throw new DirectoryNotFoundException(value);
                 }
-                
+
                 m_messageFolder = value;
             }
         }
-        
+
         public void TestEndToEndFile(string messageFilePath)
         {
             this.ProcessEndToEnd(this.ReadMessageText(messageFilePath));
         }
-        
+
         public string ProcessEndToEnd(string messageText)
         {
             string outgoingText = this.ProcessOutgoingToString(messageText);
-            string incomingText = this.ProcessIncomingToString(outgoingText);  
+            string incomingText = this.ProcessIncomingToString(outgoingText);
             Assert.Equal(messageText.Trim(), incomingText.Trim());
             return incomingText;
         }
@@ -144,17 +142,17 @@ namespace Health.Direct.Agent.Tests
         {
             return m_agentB.ProcessIncoming(messageText).SerializeMessage();
         }
-        
+
         public string ReadMessageText(string messageFilePath)
         {
             if (!Path.IsPathRooted(messageFilePath))
             {
                 messageFilePath = Path.Combine(m_messageFolder, messageFilePath);
             }
-            
+
             return File.ReadAllText(messageFilePath);
         }
-        
+
         public static void CheckErrorCode<TException, TError>(Action operation, TError expected)
             where TException : DirectException<TError>
         {
@@ -170,34 +168,34 @@ namespace Health.Direct.Agent.Tests
             }
             Assert.True(error.Equals(expected));
         }
-        
+
         public static AgentTester CreateDefault()
         {
             DirectAgent agentA = new DirectAgent(AgentTester.DefaultDomainA);
             DirectAgent agentB = new DirectAgent(AgentTester.DefaultDomainB);
-            
+
             return new AgentTester(agentA, agentB);
         }
-        
+
         public static AgentTester CreateTest()
         {
             return CreateTest(Directory.GetCurrentDirectory());
         }
-        
+
         public static AgentTester CreateTest(string basePath)
         {
             DirectAgent agentA = CreateAgent(AgentTester.DefaultDomainA, MakeCertificatesPath(basePath, "redmond"));
             DirectAgent agentB = CreateAgent(AgentTester.DefaultDomainB, MakeCertificatesPath(basePath, "nhind"));
             return new AgentTester(agentA, agentB);
         }
-        
+
         public static DirectAgent CreateAgent(string domain, string certsBasePath)
         {
             MemoryX509Store privateCerts = LoadPrivateCerts(certsBasePath, false);
             MemoryX509Store publicCerts = LoadPublicCerts(certsBasePath);
             TrustAnchorResolver anchors = new TrustAnchorResolver(
-                (IX509CertificateStore) LoadIncomingAnchors(certsBasePath),
-                (IX509CertificateStore) LoadOutgoingAnchors(certsBasePath));
+                (IX509CertificateStore)LoadIncomingAnchors(certsBasePath),
+                (IX509CertificateStore)LoadOutgoingAnchors(certsBasePath));
 
             return new DirectAgent(domain, privateCerts.CreateResolver(), publicCerts.CreateResolver(), anchors);
         }
@@ -227,7 +225,7 @@ namespace Health.Direct.Agent.Tests
         {
             return LoadCertificates(Path.Combine(certsBasePath, "Public"));
         }
-        
+
         public static MemoryX509Store LoadIncomingAnchors(string certsBasePath)
         {
             return LoadCertificates(Path.Combine(certsBasePath, "IncomingAnchors"));
@@ -237,48 +235,48 @@ namespace Health.Direct.Agent.Tests
         {
             return LoadCertificates(Path.Combine(certsBasePath, "OutgoingAnchors"));
         }
-        
+
         public static MemoryX509Store LoadCertificates(string folderPath)
         {
             return LoadCertificates(folderPath, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable);
         }
-        
+
         public static MemoryX509Store LoadCertificates(string folderPath, X509KeyStorageFlags flags)
         {
             if (string.IsNullOrEmpty(folderPath))
             {
                 throw new ArgumentException("value was null or empty", "folderPath");
             }
-            
+
             if (!Directory.Exists(folderPath))
             {
                 throw new DirectoryNotFoundException("Directory not found: " + folderPath);
             }
-            
+
             MemoryX509Store certStore = new MemoryX509Store();
-            
+
             string[] files = Directory.GetFiles(folderPath);
             for (int i = 0; i < files.Length; ++i)
             {
                 string file = files[i];
                 string ext = Path.GetExtension(file) ?? string.Empty;
                 ext = ext.ToLower();
-                
-                switch(ext)
+
+                switch (ext)
                 {
                     default:
                         certStore.ImportKeyFile(file, flags);
                         break;
-                    
+
                     case ".pfx":
                         certStore.ImportKeyFile(file, "passw0rd!", flags);
                         break;
                 }
-            } 
-            
-            return certStore;           
+            }
+
+            return certStore;
         }
-        
+
         /// <summary>
         /// Sets up standard stores for Testing
         /// WARNING: This may require elevated permissions
@@ -286,11 +284,11 @@ namespace Health.Direct.Agent.Tests
         public static void EnsureStandardMachineStores()
         {
             SystemX509Store.CreateAll();
-            
+
             string basePath = Directory.GetCurrentDirectory();
             string redmondCertsPath = MakeCertificatesPath(basePath, "redmond");
             string nhindCertsPath = MakeCertificatesPath(basePath, "nhind");
-            
+
             X509Store privateStore = CryptoUtility.OpenStoreReadWrite(SystemX509Store.PrivateCertsStoreName, StoreLocation.LocalMachine);
             if (!DoPrivateKeysExist(privateStore, redmondCertsPath))
             {
@@ -301,7 +299,7 @@ namespace Health.Direct.Agent.Tests
                 InstallPrivateKeys(privateStore, LoadPrivateCerts(nhindCertsPath, true));
             }
             privateStore.Close();
-            
+
             SystemX509Store store;
             using (store = SystemX509Store.OpenExternalEdit())
             {
@@ -329,7 +327,7 @@ namespace Health.Direct.Agent.Tests
                 }
             }
         }
-        
+
         static void InstallPrivateKeys(X509Store store, MemoryX509Store certs)
         {
             foreach (X509Certificate2 cert in certs)
@@ -343,19 +341,19 @@ namespace Health.Direct.Agent.Tests
                 store.Add(cert);
             }
         }
-        
+
         static bool DoPrivateKeysExist(X509Store store, string path)
         {
-            using(MemoryX509Store certs = LoadPrivateCerts(path, false))
+            using (MemoryX509Store certs = LoadPrivateCerts(path, false))
             {
-                foreach(X509Certificate2 cert in certs)
+                foreach (X509Certificate2 cert in certs)
                 {
                     X509Certificate2 found = store.Certificates.FindByThumbprint(cert.Thumbprint);
                     if (found == null)
                     {
                         return false;
                     }
-                    
+
                     bool hasKey = false;
                     try
                     {
@@ -363,16 +361,16 @@ namespace Health.Direct.Agent.Tests
                     }
                     catch
                     {
-                    }                    
+                    }
                     if (!hasKey)
                     {
                         return false;
                     }
                 }
             }
-            
+
             return true;
-        }                
+        }
     }
 
     /// <summary>
@@ -392,13 +390,13 @@ namespace Health.Direct.Agent.Tests
             m_b = b;
             m_includeGood = includeGood;
         }
-        
+
         public X509Certificate2Collection GetCertificates(MailAddress address)
         {
             try
             {
                 X509Certificate2Collection certs;
-                
+
                 //
                 // Very trivial - deliberately 'confuses' certs - returns certs meant for redmond when the caller
                 // asked for nhind and vice-versa. 
@@ -422,13 +420,13 @@ namespace Health.Direct.Agent.Tests
 
                 return certs;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 this.Error.NotifyEvent(this, ex);
                 throw;
-            }            
+            }
         }
-        
+
         public X509Certificate2Collection GetCertificatesForDomain(string domain)
         {
             // Not supported
@@ -459,7 +457,7 @@ namespace Health.Direct.Agent.Tests
             {
                 return (m_returnEmpty) ? new X509Certificate2Collection() : null;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 this.Error.NotifyEvent(this, ex);
                 throw;
@@ -486,7 +484,7 @@ namespace Health.Direct.Agent.Tests
             {
                 throw new InvalidOperationException();
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 this.Error.NotifyEvent(this, ex);
                 throw;
@@ -499,14 +497,14 @@ namespace Health.Direct.Agent.Tests
             {
                 throw new InvalidOperationException();
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 this.Error.NotifyEvent(this, ex);
                 throw;
             }
         }
     }
-    
+
     public class ThrowingX509Index : IX509CertificateIndex
     {
         public ThrowingX509Index()

--- a/csharp/unittests/agent/BundleResolverTests.cs
+++ b/csharp/unittests/agent/BundleResolverTests.cs
@@ -11,20 +11,15 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Net.Mail;
-using System.Security.Cryptography.Pkcs;
-using System.Security.Cryptography.X509Certificates;
 using System.IO;
-using Health.Direct.Common.Extensions;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using Health.Direct.Common.Certificates;
-using Health.Direct.Common.Caching;
+using Health.Direct.Common.Extensions;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -35,7 +30,7 @@ namespace Health.Direct.Agent.Tests
         {
             byte[] p7bData = File.ReadAllBytes(@"Certificates\Bundles\bundleNoMetadata.p7b");
             AnchorBundle bundle = null;
-            Assert.DoesNotThrow(() => bundle = new AnchorBundle(p7bData));
+            Assert.Null(Record.Exception(() => bundle = new AnchorBundle(p7bData)));
             Assert.True(!bundle.Certificates.IsNullOrEmpty());
             Assert.True(bundle.Certificates.Count == 2);
             Assert.True(string.IsNullOrEmpty(bundle.Metadata));
@@ -46,7 +41,7 @@ namespace Health.Direct.Agent.Tests
         {
             byte[] p7bData = File.ReadAllBytes(@"Certificates\Bundles\bundleWithMetadata.p7b");
             AnchorBundle bundle = null;
-            Assert.DoesNotThrow(() => bundle = new AnchorBundle(p7bData));
+            Assert.Null(Record.Exception(() => bundle = new AnchorBundle(p7bData)));
             Assert.True(!bundle.Certificates.IsNullOrEmpty());
             Assert.True(bundle.Certificates.Count == 2);
             Assert.True(!string.IsNullOrEmpty(bundle.Metadata));
@@ -57,7 +52,7 @@ namespace Health.Direct.Agent.Tests
         {
             byte[] p7bData = File.ReadAllBytes(@"Certificates\Bundles\bundlePEM.p7b");
             AnchorBundle bundle = null;
-            Assert.DoesNotThrow(() => bundle = new AnchorBundle(p7bData));
+            Assert.Null(Record.Exception(() => bundle = new AnchorBundle(p7bData)));
             Assert.True(!bundle.Certificates.IsNullOrEmpty());
         }
 
@@ -66,13 +61,13 @@ namespace Health.Direct.Agent.Tests
         {
             X509Certificate2 signingCert = AgentTester.LoadPrivateCerts("redmond").First();
             X509Certificate2Collection certs = AgentTester.LoadPrivateCerts("nhind").GetAllCertificates();
-                        
+
             byte[] p7sData = null;
-            Assert.DoesNotThrow(() => p7sData = AnchorBundle.CreateSigned(certs, signingCert));
+            Assert.Null(Record.Exception(() => p7sData = AnchorBundle.CreateSigned(certs, signingCert)));
             Assert.True(!p7sData.IsNullOrEmpty());
-            
+
             AnchorBundle bundle = null;
-            Assert.DoesNotThrow(() => bundle = new AnchorBundle(p7sData, true));
+            Assert.Null(Record.Exception(() => bundle = new AnchorBundle(p7sData, true)));
             Assert.True(!bundle.Certificates.IsNullOrEmpty());
             Assert.True(certs.Count == bundle.Certificates.Count);
         }
@@ -87,7 +82,7 @@ namespace Health.Direct.Agent.Tests
             downloader.MaxRetries = 1;
 
             AnchorBundle bundle = null;
-            Assert.DoesNotThrow(() => bundle = downloader.Download(new Uri(PatientTestBundleUrl)));
+            Assert.Null(Record.Exception(() => bundle = downloader.Download(new Uri(PatientTestBundleUrl))));
             Assert.True(!bundle.Certificates.IsNullOrEmpty());
         }
 
@@ -99,7 +94,7 @@ namespace Health.Direct.Agent.Tests
             downloader.MaxRetries = 1;
 
             X509Certificate2Collection bundle = null;
-            Assert.DoesNotThrow(() => bundle = downloader.DownloadCertificates(new Uri(PatientTestBundleUrl)));
+            Assert.Null(Record.Exception(() => bundle = downloader.DownloadCertificates(new Uri(PatientTestBundleUrl))));
             Assert.True(!bundle.IsNullOrEmpty());
         }
     }

--- a/csharp/unittests/agent/CryptographerTests.cs
+++ b/csharp/unittests/agent/CryptographerTests.cs
@@ -11,21 +11,20 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using System.Net.Mime;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-using Health.Direct.Common.Mail;
-using Health.Direct.Common.Mime;
+using System.Text;
 using Health.Direct.Common.Certificates;
 using Health.Direct.Common.Cryptography;
+using Health.Direct.Common.Mail;
+using Health.Direct.Common.Mime;
+using Xunit;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -58,13 +57,13 @@ namespace Health.Direct.Agent.Tests
             {
                 foreach (DigestAlgorithm algo in Enum.GetValues(typeof(DigestAlgorithm)))
                 {
-                    yield return new object[] { algo};
+                    yield return new object[] { algo };
                 }
             }
         }
 
         [Theory]
-        [PropertyData("DigestAlgorithms")]
+        [MemberData("DigestAlgorithms")]
         public void TestDigestMicalgParameter(DigestAlgorithm algo)
         {
             ContentType type = SignedEntity.CreateContentType(algo);
@@ -72,15 +71,15 @@ namespace Health.Direct.Agent.Tests
         }
 
         [Theory]
-        [PropertyData("DigestAlgorithms")]
+        [MemberData("DigestAlgorithms")]
         public void TestSignatureOIDs(DigestAlgorithm algo)
         {
             string messageText = m_tester.ReadMessageText("simple.eml");
             m_cryptographer.DigestAlgorithm = algo;
             SignedCms signedData = null;
-            
-            Assert.DoesNotThrow(() => signedData = m_cryptographer.CreateSignature(Encoding.ASCII.GetBytes(messageText), m_cert)); 
-            
+
+            Assert.Null(Record.Exception(() => signedData = m_cryptographer.CreateSignature(Encoding.ASCII.GetBytes(messageText), m_cert)));
+
             Assert.True(signedData.SignerInfos.Count == 1);
             Assert.True(signedData.SignerInfos[0].DigestAlgorithm.Value == SMIMECryptographer.ToDigestAlgorithmOid(algo).Value);
         }

--- a/csharp/unittests/agent/DirectAddressCollectionFacts.cs
+++ b/csharp/unittests/agent/DirectAddressCollectionFacts.cs
@@ -11,17 +11,14 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Health.Direct.Agent;
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mime;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -31,83 +28,83 @@ namespace Health.Direct.Agent.Tests
         {
             get
             {
-                yield return new object[] {1, "\"McDuff, Toby\" <toby@redmond.hsgincubator.com>", MailStandard.Headers.To};
-                yield return new object[] {1, "\"McDuff, Toby\"<toby@redmond.hsgincubator.com>", MailStandard.Headers.Cc};
-                yield return new object[] {1, "\"Toby McDuff\" <toby@redmond.hsgincubator.com>", MailStandard.Headers.Bcc};
-                yield return new object[] {1, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>", MailStandard.Headers.To};
-                yield return new object[] {2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, <biff@direct.org>", MailStandard.Headers.To};
-                yield return new object[] {2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, biff@direct.org", MailStandard.Headers.To};
-                yield return new object[] {2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, \"Biff Hooper\" <biff@direct.org>", MailStandard.Headers.To};
-                yield return new object[] {2, "\"Toby,McDuff\"<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>", MailStandard.Headers.Bcc};
-                yield return new object[] {2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>", MailStandard.Headers.Cc};
-                yield return new object[] {2, "<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>", MailStandard.Headers.To};
-                yield return new object[] {3, "<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>, <nimbu@xyz.com>", MailStandard.Headers.To};
-                yield return new object[] {3, "<toby@redmond.hsgincubator.com>, \"Biff Hooper\" <biff@direct.org>, <nimbu@xyz.com>", MailStandard.Headers.To};
-                yield return new object[] { 4, "<toby@redmond.hsgincubator.com>, <biff@direct.org>, <nimbu@xyz.com>, <violet@xyz.com>", MailStandard.Headers.Cc};
+                yield return new object[] { 1, "\"McDuff, Toby\" <toby@redmond.hsgincubator.com>", MailStandard.Headers.To };
+                yield return new object[] { 1, "\"McDuff, Toby\"<toby@redmond.hsgincubator.com>", MailStandard.Headers.Cc };
+                yield return new object[] { 1, "\"Toby McDuff\" <toby@redmond.hsgincubator.com>", MailStandard.Headers.Bcc };
+                yield return new object[] { 1, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>", MailStandard.Headers.To };
+                yield return new object[] { 2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, <biff@direct.org>", MailStandard.Headers.To };
+                yield return new object[] { 2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, biff@direct.org", MailStandard.Headers.To };
+                yield return new object[] { 2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, \"Biff Hooper\" <biff@direct.org>", MailStandard.Headers.To };
+                yield return new object[] { 2, "\"Toby,McDuff\"<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>", MailStandard.Headers.Bcc };
+                yield return new object[] { 2, "\"Toby McDuff\"<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>", MailStandard.Headers.Cc };
+                yield return new object[] { 2, "<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>", MailStandard.Headers.To };
+                yield return new object[] { 3, "<toby@redmond.hsgincubator.com>, \"Biff,Hooper\" <biff@direct.org>, <nimbu@xyz.com>", MailStandard.Headers.To };
+                yield return new object[] { 3, "<toby@redmond.hsgincubator.com>, \"Biff Hooper\" <biff@direct.org>, <nimbu@xyz.com>", MailStandard.Headers.To };
+                yield return new object[] { 4, "<toby@redmond.hsgincubator.com>, <biff@direct.org>, <nimbu@xyz.com>, <violet@xyz.com>", MailStandard.Headers.Cc };
             }
         }
 
         [Theory]
-        [PropertyData("Addresses")]
+        [MemberData("Addresses")]
         public void Parse(int addressCount, string source, string headerName)
         {
             DirectAddressCollection addresses = null;
-            Assert.DoesNotThrow(() => addresses = DirectAddressCollection.Parse(source));
+            Assert.Null(Record.Exception(() => addresses = DirectAddressCollection.Parse(source)));
             Assert.True(addresses.Count == addressCount);
         }
 
         [Theory]
-        [PropertyData("Addresses")]
+        [MemberData("Addresses")]
         public void ToHeaderUnfolded(int addressCount, string source, string headerName)
         {
             DirectAddressCollection addresses = null;
-            Assert.DoesNotThrow(() => addresses = DirectAddressCollection.Parse(source));
-            
-            Header header = null;   
-            Assert.DoesNotThrow(() => header = addresses.ToHeader(headerName));
+            Assert.Null(Record.Exception(() => addresses = DirectAddressCollection.Parse(source)));
+
+            Header header = null;
+            Assert.Null(Record.Exception(() => header = addresses.ToHeader(headerName)));
             Assert.True(string.Equals(header.Name, headerName));
 
             DirectAddressCollection reparsedAddresses = null;
-            Assert.DoesNotThrow(() => reparsedAddresses = DirectAddressCollection.Parse(header.Value));
+            Assert.Null(Record.Exception(() => reparsedAddresses = DirectAddressCollection.Parse(header.Value)));
             Assert.True(reparsedAddresses.Count == addressCount);
         }
-                
+
         [Theory]
-        [PropertyData("Addresses")]
+        [MemberData("Addresses")]
         public void ToHeader(int addressCount, string source, string headerName)
         {
             DirectAddressCollection addresses = null;
-            Assert.DoesNotThrow(() => addresses = DirectAddressCollection.Parse(source));
+            Assert.Null(Record.Exception(() => addresses = DirectAddressCollection.Parse(source)));
             Assert.True(addresses.Count == addressCount);
-            
-            Header header = null;   
-            Assert.DoesNotThrow(() => header = addresses.ToHeader(headerName));
+
+            Header header = null;
+            Assert.Null(Record.Exception(() => header = addresses.ToHeader(headerName)));
             Assert.True(string.Equals(header.Name, headerName));
-            
+
             string foldedText = null;
-            Assert.DoesNotThrow(() => foldedText = header.SourceText.ToString());
+            Assert.Null(Record.Exception(() => foldedText = header.SourceText.ToString()));
             Assert.True(!string.IsNullOrEmpty(foldedText));
 
             string[] foldedParts = foldedText.Split(new string[] { MailStandard.CRLF }, StringSplitOptions.None);
             Assert.True(foldedParts.Length == addressCount);
-            
+
             string entity = foldedText + MailStandard.CRLF;
             Header[] reparsedHeaders = null;
-            Assert.DoesNotThrow(() => reparsedHeaders = MimeParser.ReadHeaders(entity).ToArray());
+            Assert.Null(Record.Exception(() => reparsedHeaders = MimeParser.ReadHeaders(entity).ToArray()));
             Assert.True(reparsedHeaders.Length == 1);
             Assert.True(reparsedHeaders[0].Name == headerName);
 
             DirectAddressCollection reparsedAddresses = null;
-            Assert.DoesNotThrow(() => reparsedAddresses = DirectAddressCollection.Parse(reparsedHeaders[0].Value));
+            Assert.Null(Record.Exception(() => reparsedAddresses = DirectAddressCollection.Parse(reparsedHeaders[0].Value)));
             Assert.True(reparsedAddresses.Count == addressCount);
-        }        
-        
+        }
+
         [Fact]
         public void ToHeaderNull()
         {
             DirectAddressCollection addresses = new DirectAddressCollection();
             Header header = null;
-            Assert.DoesNotThrow(() => header = addresses.ToHeader(MailStandard.Headers.To));
+            Assert.Null(Record.Exception(() => header = addresses.ToHeader(MailStandard.Headers.To)));
             Assert.True(header == null);
         }
     }

--- a/csharp/unittests/agent/DnsResolverTest.cs
+++ b/csharp/unittests/agent/DnsResolverTest.cs
@@ -12,8 +12,8 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -21,49 +21,47 @@ using System.Net.Mail;
 using System.Security.Cryptography.X509Certificates;
 using Health.Direct.Agent.Config;
 using Health.Direct.Common.Certificates;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
     public class DnsResolverTest
     {
         public const string ServerIP = "127.0.0.1";
-        
+
         public static IEnumerable<object[]> GoodAddresses
         {
             get
             {
-                yield return new[] {"bob@nhind.hsgincubator.com"};
-                yield return new[] {"biff@nhind.hsgincubator.com"};
-                yield return new[] {"gatewaytest@hotmail.com"};
+                yield return new[] { "bob@nhind.hsgincubator.com" };
+                yield return new[] { "biff@nhind.hsgincubator.com" };
+                yield return new[] { "gatewaytest@hotmail.com" };
             }
         }
-        
+
         [Fact]
         public void CreateResolverTest()
         {
             DnsCertResolverSettings settings = new DnsCertResolverSettings()
-                    {
-                        ServerIP = "1.2.3.4",
-                        TimeoutMilliseconds = 7000
-                    };
-            
-            ICertificateResolver resolver = settings.CreateResolver();  
-            Validate(resolver, settings.ServerIP, settings.TimeoutMilliseconds);           
+            {
+                ServerIP = "1.2.3.4",
+                TimeoutMilliseconds = 7000
+            };
+
+            ICertificateResolver resolver = settings.CreateResolver();
+            Validate(resolver, settings.ServerIP, settings.TimeoutMilliseconds);
             Assert.True(resolver is DnsCertResolver);
-            
+
             settings.BackupServerIP = "3.4.5.6";
             resolver = settings.CreateResolver();
             Assert.True(resolver is CertificateResolverCollection);
-                    
+
             CertificateResolverCollection resolvers = resolver as CertificateResolverCollection;
             Assert.True(resolvers.Count == 2);
             Validate(resolvers[0], settings.ServerIP, settings.TimeoutMilliseconds);
             Validate(resolvers[1], settings.BackupServerIP, settings.TimeoutMilliseconds);
         }
-        
+
         void Validate(ICertificateResolver resolver, string ip, int timeout)
         {
             Assert.True(resolver is DnsCertResolver);
@@ -71,9 +69,9 @@ namespace Health.Direct.Agent.Tests
             Assert.True(dnsResolver.Server.ToString() == ip);
             Assert.True(dnsResolver.Timeout.TotalMilliseconds == timeout);
         }
-                      
+
         [Theory(Skip = "Requires Bind Server to be running on the local server")]
-        [PropertyData("GoodAddresses")]
+        [MemberData("GoodAddresses")]
         public void GetCertificateWithGoodAddress(string address)
         {
             var resolver = new DnsCertResolver(IPAddress.Parse(ServerIP)

--- a/csharp/unittests/agent/MessageEnvelopeFacts.cs
+++ b/csharp/unittests/agent/MessageEnvelopeFacts.cs
@@ -11,18 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Health.Direct.Agent;
+using Health.Direct.Common.Extensions;
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mime;
-using Health.Direct.Common.Extensions;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -53,45 +48,45 @@ Yo. Wassup?";
             toRemove.Add(new DirectAddress("<joe@nhind.hsgincubator.com>"));
             toRemove.Add(new DirectAddress("<laura@nhind.hsgincubator.com>"));
             toRemove.Add(new DirectAddress("<bob@nhind.hsgincubator.com>"));
-            
-            Assert.DoesNotThrow(() => envelope.RemoveFromRoutingHeaders(toRemove));
-            
+
+            Assert.Null(Record.Exception(() => envelope.RemoveFromRoutingHeaders(toRemove)));
+
             string outputText = null;
-            Assert.DoesNotThrow(() => outputText = envelope.SerializeMessage());
-            
+            Assert.Null(Record.Exception(() => outputText = envelope.SerializeMessage()));
+
             Message outputMessage = Message.Load(outputText);
             Assert.True(outputMessage.Bcc == null);
-            
+
             this.CheckHeaderRaw(outputMessage.Cc, 2);
-            this.CheckCollection(outputMessage.Cc, 
-                                new string[] {"frank@nhind.hsgincubator.com", "fenton@nhind.hsgincubator.com"},
-                                new string[] {"joe@nhind.hsgincubator.com>", "laura@nhind.hsgincubator.com"});
-            
+            this.CheckCollection(outputMessage.Cc,
+                                new string[] { "frank@nhind.hsgincubator.com", "fenton@nhind.hsgincubator.com" },
+                                new string[] { "joe@nhind.hsgincubator.com>", "laura@nhind.hsgincubator.com" });
+
             this.CheckHeaderRaw(outputMessage.To, 1);
             this.CheckCollection(outputMessage.To,
-                                new string[] { "biff@nhind.hsgincubator.com"},
-                                new string[] { "bob@nhind.hsgincubator.com"});
-                                 
+                                new string[] { "biff@nhind.hsgincubator.com" },
+                                new string[] { "bob@nhind.hsgincubator.com" });
+
         }
-        
+
         void CheckHeaderRaw(Header header, int addressCount)
         {
             Assert.True(header != null);
-            
+
             string foldedText = header.SourceText.ToString();
             string[] foldedParts = foldedText.Split(new string[] { MailStandard.CRLF }, StringSplitOptions.None);
             Assert.True(foldedParts.Length == addressCount);
         }
-                
+
         void CheckCollection(Header header, string[] contains, string[] doesNotContain)
         {
             Assert.True(header != null);
-            
+
             DirectAddressCollection collection = null;
-            Assert.DoesNotThrow(() => collection= DirectAddressCollection.Parse(header.Value));
+            Assert.Null(Record.Exception(() => collection = DirectAddressCollection.Parse(header.Value)));
             if (!contains.IsNullOrEmpty())
             {
-                foreach(string addr in contains)
+                foreach (string addr in contains)
                 {
                     Assert.True(collection.Contains(addr));
                 }

--- a/csharp/unittests/agent/PluginResolverTests.cs
+++ b/csharp/unittests/agent/PluginResolverTests.cs
@@ -11,16 +11,14 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Security.Cryptography.X509Certificates;
 using System.Net.Mail;
-using System.Xml;
-using System.Xml.Serialization;
+using System.Security.Cryptography.X509Certificates;
 using Health.Direct.Agent.Config;
-using Health.Direct.Common.Container;
 using Health.Direct.Common.Certificates;
+using Health.Direct.Common.Container;
 using Xunit;
 
 namespace Health.Direct.Agent.Tests
@@ -62,7 +60,7 @@ namespace Health.Direct.Agent.Tests
             }
         }
 
-        
+
         #endregion
 
         #region IPlugin Members
@@ -291,7 +289,7 @@ namespace Health.Direct.Agent.Tests
 
             Assert.NotNull(agent.TrustAnchors);
             Assert.True(agent.TrustAnchors is MachineAnchorResolverProxy);
-            
+
             X509Certificate2Collection certs = agent.TrustAnchors.IncomingAnchors.GetCertificatesForDomain("nhind.hsgincubator.com");
             Assert.NotNull(certs);
             Assert.True(certs.Count > 0);

--- a/csharp/unittests/agent/PlugingDomainResolverTests.cs
+++ b/csharp/unittests/agent/PlugingDomainResolverTests.cs
@@ -1,8 +1,22 @@
-﻿using System;
+﻿/* 
+ Copyright (c) 2010, Direct Project
+ All rights reserved.
+
+ Authors:
+    Umesh Madan     umeshma@microsoft.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
-using System.Text;
 using System.Xml.Serialization;
 using Health.Direct.Agent.Config;
 using Health.Direct.Common.Container;
@@ -10,7 +24,6 @@ using Health.Direct.Common.Domains;
 using Health.Direct.Common.Extensions;
 using Health.Direct.Common.Mail;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -53,7 +66,7 @@ namespace Health.Direct.Agent.Tests
 
         #endregion
 
-        
+
     }
 
 
@@ -97,7 +110,7 @@ namespace Health.Direct.Agent.Tests
     public class PluggedStaticDomainResolver : IDomainResolver
     {
         private Dictionary<string, string> m_domains = new Dictionary<string, string>(MailStandard.Comparer);
-        
+
 
         public PluggedStaticDomainResolver(string[] domains)
         {
@@ -140,12 +153,11 @@ namespace Health.Direct.Agent.Tests
 
             return true;
         }
-}
+    }
 
     public class PluggingDomainResolverTests
     {
         #region data
-
 
         public const string TestXml = @"
             <AgentSettings>
@@ -199,7 +211,6 @@ namespace Health.Direct.Agent.Tests
             </AgentSettings>
             ";
 
-
         public const string TestMissingDomainsXml = @"
             <AgentSettings>
                  
@@ -252,10 +263,10 @@ namespace Health.Direct.Agent.Tests
         {
             AgentSettings settings = AgentSettings.Load(TestXml);
             DirectAgent agent = settings.CreateAgent();
-            
+
             Assert.True(agent.Domains.Domains.Count() > 0);
             Assert.True(agent.Domains.IsManaged(new MailAddress("hobojoe@" + domain)) == result);
-            
+
         }
 
         [Fact]
@@ -264,7 +275,5 @@ namespace Health.Direct.Agent.Tests
             AgentSettings settings = AgentSettings.Load(TestMissingDomainsXml);
             Assert.Throws<ArgumentException>(() => settings.CreateAgent());
         }
-               
-        
     }
 }

--- a/csharp/unittests/agent/Properties/AssemblyInfo.cs
+++ b/csharp/unittests/agent/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/csharp/unittests/agent/TestCertificates.cs
+++ b/csharp/unittests/agent/TestCertificates.cs
@@ -15,7 +15,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 */
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-
 using Health.Direct.Common.Certificates;
 
 namespace Health.Direct.Agent.Tests
@@ -31,9 +30,9 @@ namespace Health.Direct.Agent.Tests
         }
 
         public static MemoryX509Store ChainCertsStore;
-        public static MemoryX509Store PublicCertsStore;        
+        public static MemoryX509Store PublicCertsStore;
         public static X509Certificate2Collection AllPublicCerts;
-        
+
         public static MemoryX509Store LoadCertificateFolder(string folderPath)
         {
             string path = FullPath(folderPath);
@@ -42,7 +41,7 @@ namespace Health.Direct.Agent.Tests
 
             return store;
         }
-        
+
         public static X509Certificate2Collection LoadAllPublic()
         {
             using (SystemX509Store store = SystemX509Store.OpenExternal())

--- a/csharp/unittests/agent/TestCerts.cs
+++ b/csharp/unittests/agent/TestCerts.cs
@@ -11,15 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Health.Direct.Common.Certificates;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
@@ -29,12 +27,12 @@ namespace Health.Direct.Agent.Tests
         {
             AgentTester.EnsureStandardMachineStores();
         }
-        
+
         public static IEnumerable<object[]> PrivateCerts
         {
             get
             {
-                using(SystemX509Store store = SystemX509Store.OpenPrivate())
+                using (SystemX509Store store = SystemX509Store.OpenPrivate())
                 {
                     foreach (X509Certificate2 cert in store)
                     {
@@ -71,7 +69,7 @@ namespace Health.Direct.Agent.Tests
                 }
             }
         }
-        
+
         public static IEnumerable<object[]> AllCerts
         {
             get
@@ -86,18 +84,16 @@ namespace Health.Direct.Agent.Tests
                     yield return o;
                 }
             }
-        }        
-                
+        }
+
         [Theory]
-        [PropertyData("AllCerts")]
+        [MemberData("AllCerts")]
         public void TestNameExtraction(X509Certificate2 cert)
         {
             string name = cert.ExtractEmailNameOrName();
             Assert.False(string.IsNullOrEmpty(name));
             Assert.True(cert.MatchEmailNameOrName(name));
         }
-
-
 
         /// <summary>
         /// Certificate extracted from the NIST INVALID_CERT test.
@@ -109,7 +105,6 @@ namespace Health.Direct.Agent.Tests
         [Fact]
         public void TestVerifySignature_dNSName_in_subjectAltName_doesNotMatch_Health_Internet_Domain()
         {
-
             string signingCert = @"MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqGSIb3DQEHAQAAoIAwggQhMIID
 iqADAgECAghs4QKo+HXxyzANBgkqhkiG9w0BAQUFADCBpDEkMCIGCSqGSIb3DQEJARYVdHJhbnNw
 b3J0LXRlc3Rpbmcub3JnMR4wHAYDVQQDDBV0cmFuc3BvcnQtdGVzdGluZy5vcmcxCzAJBgNVBAYT
@@ -146,13 +141,12 @@ g9DY8Y/ubZz99nUCA0ZEMUYEaLG+gWjzD0TXU+IBKmzX55p2DktPBSGz+rO3TdDzCa3oRJsHBIFp
 
             X509Certificate2 cert = new X509Certificate2();
             cert.Import(Encoding.UTF8.GetBytes(signingCert));
-            
+
             Assert.Equal("foo.transport-testing.org", cert.GetNameInfo(X509NameType.DnsFromAlternativeName, false));
 
             Assert.False(cert.MatchEmailNameOrName("InvalidCert@ttt.transport-testing.org"));
             Assert.False(cert.MatchDnsOrEmailOrName("ttt.transport-testing.org"));
         }
-
     }
 
     public class TestCertFind
@@ -187,7 +181,7 @@ g9DY8Y/ubZz99nUCA0ZEMUYEaLG+gWjzD0TXU+IBKmzX55p2DktPBSGz+rO3TdDzCa3oRJsHBIFp
         }
 
         [Theory]
-        [PropertyData("MixedNames")]
+        [MemberData("MixedNames")]
         public void TestFindMixed(string name, bool shouldMatch)
         {
             bool found = (m_certs.Find(x => x.MatchEmailNameOrName(name)) != null);
@@ -195,7 +189,7 @@ g9DY8Y/ubZz99nUCA0ZEMUYEaLG+gWjzD0TXU+IBKmzX55p2DktPBSGz+rO3TdDzCa3oRJsHBIFp
         }
 
         [Theory]
-        [PropertyData("Names")]
+        [MemberData("Names")]
         public void TestFindNames(string name, bool shouldMatch)
         {
             bool found = (m_certs.FindByName(name) != null);

--- a/csharp/unittests/agent/TestEnvelope.cs
+++ b/csharp/unittests/agent/TestEnvelope.cs
@@ -1,25 +1,34 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿/* 
+ Copyright (c) 2010, Direct Project
+ All rights reserved.
+
+ Authors:
+    Umesh Madan     umeshma@microsoft.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 using System.IO;
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mime;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Agent.Tests
 {
     public class TestEnvelope
     {
         string m_messageFolder;
-        
+
         public TestEnvelope()
         {
             m_messageFolder = Path.Combine(Directory.GetCurrentDirectory(), "TestMessages");
         }
-        
+
         [Fact]
         public void TestIncomingBasic()
         {
@@ -30,17 +39,17 @@ namespace Health.Direct.Agent.Tests
                     new DirectAddress("biff@nhind.hsgincubator.com")
                     }
                 );
-            
+
             IncomingMessage incoming = new IncomingMessage(message, rcpto, new DirectAddress("toby@redmond.hsgincubator.com"));
             Assert.True(incoming.Recipients.Count == 2);
-            
+
             DirectAddressCollection routingRecipients = incoming.GetRecipientsInRoutingHeaders();
             Assert.True(routingRecipients.Count == 1);
-            
+
             Assert.False(incoming.AreAddressesInRoutingHeaders(rcpto));
             incoming.Recipients.Remove(x => MimeStandard.Equals(x.Address, "foo@bar.com"));
             Assert.True(incoming.AreAddressesInRoutingHeaders(rcpto));
-            
+
             message.ToValue = "toby@redmond.hsgincubator.com";
             incoming = new IncomingMessage(message, rcpto, new DirectAddress("toby@redmond.hsgincubator.com"));
             Assert.False(incoming.AreAddressesInRoutingHeaders(rcpto));
@@ -49,12 +58,12 @@ namespace Health.Direct.Agent.Tests
             incoming = new IncomingMessage(message, rcpto, new DirectAddress("toby@redmond.hsgincubator.com"));
             Assert.False(incoming.AreAddressesInRoutingHeaders(rcpto));
         }
-        
+
         Message LoadMessage(string messageFile)
         {
             return MailParser.ParseMessage(ReadMessageText(messageFile));
         }
-        
+
         public string ReadMessageText(string messageFilePath)
         {
             if (!Path.IsPathRooted(messageFilePath))

--- a/csharp/unittests/agent/TrustChainTests.cs
+++ b/csharp/unittests/agent/TrustChainTests.cs
@@ -11,14 +11,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
 
 using System.Net.Mail;
 using System.Security.Cryptography.X509Certificates;
-
 using Health.Direct.Common.Certificates;
-
 using Xunit;
 
 namespace Health.Direct.Agent.Tests
@@ -30,7 +27,7 @@ namespace Health.Direct.Agent.Tests
         TrustChainValidator m_validator;
         X509Certificate2Collection m_endCerts;
         X509Certificate2Collection m_trustedAnchors;
-        
+
         public TrustChainTests()
         {
             m_store = TestCertificates.ChainCertsStore.Clone();
@@ -43,24 +40,24 @@ namespace Health.Direct.Agent.Tests
             m_endCerts = m_resolver.GetCertificates(new MailAddress("foo@end.xyz"));
             m_trustedAnchors = m_resolver.GetCertificatesForDomain("root.xyz");
         }
-        
+
         [Fact]
         public void TestValidTrustChain()
         {
             Assert.True(!m_endCerts.IsNullOrEmpty());
             Assert.True(!m_trustedAnchors.IsNullOrEmpty());
-            
+
             //
             // Ok, verify certs..
             //            
-            foreach(X509Certificate2 cert in m_endCerts)
+            foreach (X509Certificate2 cert in m_endCerts)
             {
                 X509Certificate2Collection issuers = m_validator.ResolveIntermediateIssuers(cert);
                 Assert.True(!issuers.IsNullOrEmpty() && issuers.Count == 3);
                 Assert.True(m_validator.IsTrustedCertificate(cert, m_trustedAnchors));
-            }            
+            }
         }
-        
+
         [Fact]
         public void TestFailMaxLength()
         {
@@ -85,19 +82,19 @@ namespace Health.Direct.Agent.Tests
                 Assert.False(m_validator.IsTrustedCertificate(cert, m_trustedAnchors));
             }
         }
-        
+
         [Fact]
         public void TestDnsAltName()
         {
             MemoryX509Store dnsCerts = TestCertificates.LoadCertificateFolder("Dns");
-            foreach(X509Certificate2 dnsCert in dnsCerts)
+            foreach (X509Certificate2 dnsCert in dnsCerts)
             {
                 string dnsName = dnsCert.GetNameInfo(X509NameType.DnsName, false);
                 Assert.True(dnsCert.MatchDnsName(dnsName));
                 Assert.True(dnsCert.MatchDnsOrEmailOrName(dnsName));
             }
         }
-        
+
         TrustChainValidator CreateValidator()
         {
             TrustChainValidator validator = new TrustChainValidator();
@@ -108,7 +105,7 @@ namespace Health.Direct.Agent.Tests
                 X509ChainStatusFlags.NotSignatureValid |
                 X509ChainStatusFlags.CtlNotTimeValid |
                 X509ChainStatusFlags.CtlNotSignatureValid;
-            
+
             return validator;
         }
     }

--- a/csharp/unittests/agent/TrustModelWithPolicyTests.cs
+++ b/csharp/unittests/agent/TrustModelWithPolicyTests.cs
@@ -11,7 +11,6 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
 
 using System;
@@ -28,11 +27,8 @@ namespace Health.Direct.Agent.Tests
     public class TrustModelWithPolicyTests
     {
         readonly Mock<TrustChainValidator> mockTrustChainValidator = new Mock<TrustChainValidator>();
-        
-        
         readonly Mock<IPolicyFilter> mockPolicyFilter = new Mock<IPolicyFilter>();
         readonly Mock<IPolicyResolver> mockPolicyResolver = new Mock<IPolicyResolver>();
-
 
         [Fact]
         public void TestIsCertPolicyCompiant_NoResolver_NoFilter_AssertTrue()
@@ -54,7 +50,6 @@ namespace Health.Direct.Agent.Tests
             trustModel.IsCertPolicyCompliant(new MailAddress("me@test.com"), mockCert.Object).Should().BeTrue();
         }
 
-
         [Fact]
         public void TestIsCertPolicyCompiant_PolicyCompliant_AssertTrue()
         {
@@ -64,18 +59,17 @@ namespace Health.Direct.Agent.Tests
             mockPolicyFilter.Setup(
                 filter => filter.IsCompliant(It.IsAny<X509Certificate2>(), It.IsAny<IPolicyExpression>()))
                 .Returns(true);
-            
+
             Mock<IPolicyExpression> mockExpression = new Mock<IPolicyExpression>();
 
             mockPolicyResolver.Setup(
                 resolver => resolver.GetIncomingPolicy(new MailAddress("me@test.com")))
-                .Returns(new List<IPolicyExpression>{mockExpression.Object});
+                .Returns(new List<IPolicyExpression> { mockExpression.Object });
 
             trustModel.IsCertPolicyCompliant(new MailAddress("me@test.com"), mockCert.Object).Should().BeTrue();
 
             mockPolicyFilter.VerifyAll();
         }
-
 
         [Fact]
         public void TestIsCertPolicyCompiant_PolicyNotCompliant_AssertFalse()
@@ -98,7 +92,6 @@ namespace Health.Direct.Agent.Tests
             mockPolicyFilter.VerifyAll();
         }
 
-
         [Fact]
         public void TestIsCertPolicyCompiant_MissingRequiredField_AssertFalse()
         {
@@ -119,7 +112,6 @@ namespace Health.Direct.Agent.Tests
 
             mockPolicyFilter.VerifyAll();
         }
-
 
         [Fact]
         public void TestIsCertPolicyCompiant_PolicyExpressionError_AssertException()
@@ -143,6 +135,5 @@ namespace Health.Direct.Agent.Tests
 
             mockPolicyFilter.VerifyAll();
         }
-
     }
 }

--- a/csharp/unittests/agent/agent.tests.csproj
+++ b/csharp/unittests/agent/agent.tests.csproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\build\</SolutionDir>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -12,10 +16,6 @@
     <AssemblyName>Health.Direct.Agent.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -32,7 +32,6 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\build\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -58,25 +57,33 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FluentAssertions">
-      <HintPath>..\..\build\packages\FluentAssertions.2.1.0.0\lib\net45\FluentAssertions.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\FluentAssertions.2.1.0.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
-      <HintPath>..\..\build\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core"/>
+    <Reference Include="System.Core" />
     <Reference Include="System.Security" />
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit, Version=1.6.1.1521, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\external\xunit\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.extensions, Version=1.6.1.1521, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\external\xunit\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -273,16 +280,18 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
   <PropertyGroup>
     <PostBuildEvent>XCOPY /I /Q /R /S /Y "$(ProjectDir)\Certificates\*.*" "$(SolutionDir)..\bin\$(ConfigurationName)\Certificates"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>

--- a/csharp/unittests/agent/packages.config
+++ b/csharp/unittests/agent/packages.config
@@ -2,4 +2,12 @@
 <packages>
   <package id="FluentAssertions" version="2.1.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/csharp/unittests/common/Caching/DnsClientWithCacheFacts.cs
+++ b/csharp/unittests/common/Caching/DnsClientWithCacheFacts.cs
@@ -11,16 +11,14 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
  */
+
 using System;
 using System.Collections.Generic;
 using Health.Direct.Common.Caching;
 using Health.Direct.Common.Dns;
 using Health.Direct.Common.DnsResolver;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Caching
 {
@@ -63,7 +61,7 @@ namespace Health.Direct.Common.Tests.Caching
             : base(DumpIsEnabled)
         {
             m_cache = new DnsResponseCache(Guid.NewGuid().ToString("D"));
-            m_client = new DnsClientWithCache(PublicDns) { Timeout = TimeSpan.FromSeconds(5), Cache = m_cache};
+            m_client = new DnsClientWithCache(PublicDns) { Timeout = TimeSpan.FromSeconds(5), Cache = m_cache };
             m_client.MaxRetries = 1;
             m_clientNoCache = new DnsClient(PublicDns) { Timeout = TimeSpan.FromSeconds(5) };
             m_clientNoCache.MaxRetries = 1;
@@ -103,13 +101,13 @@ namespace Health.Direct.Common.Tests.Caching
             Dump("ensuring item is stored in cache");
             Assert.NotNull(res);
         }
-        
+
         /// <summary>
         /// Confirms ability of code to resolve certs using the dns caching client method ResolveCERT, ensures items are in cache
         /// </summary>
         /// <param name="domain">domain name to be resolved</param>
         [Theory(Skip = "Requires remote DNS call on port 53.")]
-        [PropertyData("CertDomainNames")]
+        [MemberData("CertDomainNames")]
         public void ResolveCertEnsureInCache(string domain)
         {
             // try with ResolveCert
@@ -128,8 +126,8 @@ namespace Health.Direct.Common.Tests.Caching
         /// confirms ability of code to resolve certs using the dns caching client method ResolveCERT
         /// </summary>
         /// <param name="domain">domain name to be resolved</param>
-        [Theory(Skip="Requires remote DNS call on port 53.")]
-        [PropertyData("CertDomainNames")]
+        [Theory(Skip = "Requires remote DNS call on port 53.")]
+        [MemberData("CertDomainNames")]
         public void ResolveCERTFromNameServerEnsureInCache(string domain)
         {
             // try with ResolveCert
@@ -137,7 +135,7 @@ namespace Health.Direct.Common.Tests.Caching
 
             IEnumerable<CertRecord> results = m_client.ResolveCERTFromNameServer(domain);
             Assert.True(results != null, domain);
-            
+
             Dump("ensuring item is stored in cache");
             DnsResponse res = m_client.Cache.Get(new DnsQuestion(domain
                                                                  , DnsStandard.RecordType.CERT));
@@ -165,7 +163,7 @@ namespace Health.Direct.Common.Tests.Caching
             Dump("ensuring item is stored in cache");
             Assert.NotNull(res);
         }
-        
+
         /// <summary>
         /// confirms ability to resolve and cache TXT records
         /// </summary>

--- a/csharp/unittests/common/Caching/DnsResponseCacheFacts.cs
+++ b/csharp/unittests/common/Caching/DnsResponseCacheFacts.cs
@@ -12,13 +12,13 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using Health.Direct.Common.Caching;
 using Health.Direct.Common.DnsResolver;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Caching
@@ -27,7 +27,6 @@ namespace Health.Direct.Common.Tests.Caching
     {
         // set this to true if dump statements are needed for debugging purposes
         private const bool DumpIsEnabled = false;
-
 
         private const string m_filePath = @"..\..\..\..\common.metadata\dnsresponses";
 
@@ -87,7 +86,7 @@ namespace Health.Direct.Common.Tests.Caching
                 }
 
                 // ensure that the qusetion QName matches the name of the mocked entry
-                Assert.True(dr.Question.Domain.ToLower().Contains(s.ToLower().Replace("aname.","")));
+                Assert.True(dr.Question.Domain.ToLower().Contains(s.ToLower().Replace("aname.", "")));
             }
         }
 
@@ -137,7 +136,7 @@ namespace Health.Direct.Common.Tests.Caching
 
             // populate the entires
             PopulateMockDnsARecordResponseEntries();
-            
+
             // force static TTL
             ForceTtlTime(m_basettl);
 
@@ -201,7 +200,7 @@ namespace Health.Direct.Common.Tests.Caching
                 //---populate the cache
                 PopulateBasicCache();
 
-                
+
                 //----------------------------------------------------------------------------------------------------
                 //---get the first response, we are going to remove it
                 DnsResponse dr = m_responses[0];
@@ -259,7 +258,6 @@ namespace Health.Direct.Common.Tests.Caching
 
         }
 
-
         /// <summary>
         /// checks for duplicates inside the cache and how they are handled
         /// Remarks:
@@ -268,8 +266,6 @@ namespace Health.Direct.Common.Tests.Caching
         [Fact]
         public void CacheDuplicateTest()
         {
-
-
             try
             {
                 //----------------------------------------------------------------------------------------------------
@@ -298,16 +294,12 @@ namespace Health.Direct.Common.Tests.Caching
                 //---make sure that there are only the X number of items in the cache
                 Assert.Equal(m_responses.Count
                              , m_drrc.CacheCount);
-
-
             }
             finally
             {
                 m_drrc.RemoveAll();
             }
-
         }
-
 
         /// <summary>
         /// checks to make sure that ttl is respected in the cache

--- a/csharp/unittests/common/Caching/DnsResponseToBinExample.cs
+++ b/csharp/unittests/common/Caching/DnsResponseToBinExample.cs
@@ -12,19 +12,16 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-
 using Health.Direct.Common.DnsResolver;
-
 using Security.Cryptography;
 using Security.Cryptography.X509Certificates;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Caching
 {
@@ -97,9 +94,10 @@ namespace Health.Direct.Common.Tests.Caching
             }
         }
 
-        public DnsResponseToBinExample(){
-		
-            m_client = new DnsClient(PublicDns) {Timeout = TimeSpan.FromSeconds(10) };
+        public DnsResponseToBinExample()
+        {
+
+            m_client = new DnsClient(PublicDns) { Timeout = TimeSpan.FromSeconds(10) };
         }
 
         //---these "tests" are purely examples of how to create mock responses, they are skipped out as they alter the file system 
@@ -123,7 +121,8 @@ namespace Health.Direct.Common.Tests.Caching
             byte[] bytes = buff.CreateReader().ReadBytes();
             string path = Path.Combine(DnsResponsePath, string.Format("aname.{0}.bin", domain)).Replace("www.", "");
             Console.WriteLine("Creating {0}", path);
-            using (FileStream s = new FileStream(path,FileMode.OpenOrCreate)){
+            using (FileStream s = new FileStream(path, FileMode.OpenOrCreate))
+            {
                 s.Write(bytes
                         , 0
                         , bytes.Length);
@@ -234,7 +233,8 @@ namespace Health.Direct.Common.Tests.Caching
             DnsBuffer buff = new DnsBuffer();
             byte[] bytes;
             AddressRecord arec = new AddressRecord(domain
-                , "127.0.0.1") {TTL = 1000};
+                , "127.0.0.1")
+            { TTL = 1000 };
             arec.Serialize(buff);
 
             string path = Path.Combine(DNSRECORDSEPATH, string.Format("aname.{0}.bin", domain));
@@ -248,7 +248,7 @@ namespace Health.Direct.Common.Tests.Caching
                 s.Close();
             }
 
-            
+
             //----------------------------------------------------------------------------------------------------
             //---read the stream from the bytes
             using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
@@ -269,7 +269,8 @@ namespace Health.Direct.Common.Tests.Caching
                 , 2
                 , 3
                 , 4
-                , 5) {TTL = 2000};
+                , 5)
+            { TTL = 2000 };
             buff = new DnsBuffer();
             soa.Serialize(buff);
 
@@ -304,7 +305,8 @@ namespace Health.Direct.Common.Tests.Caching
             //----------------------------------------------------------------------------------------------------------------
             MXRecord mx = new MXRecord(domain
                 , string.Format("mx.{0}", domain)
-                , 1) {TTL = 2000};
+                , 1)
+            { TTL = 2000 };
 
             buff = new DnsBuffer();
             mx.Serialize(buff);
@@ -338,7 +340,8 @@ namespace Health.Direct.Common.Tests.Caching
             CertRecord cert = new CertRecord(new DnsX509Cert(CreateNamedKeyCertificate(new CertData(domain
                 , domain
                 , string.Format("CN={0}", domain)
-                , "")))) {TTL = 2000};
+                , ""))))
+            { TTL = 2000 };
 
             buff = new DnsBuffer();
             cert.Serialize(buff);
@@ -368,36 +371,36 @@ namespace Health.Direct.Common.Tests.Caching
             Console.WriteLine(cert.Cert.Certificate.NotAfter);
         }
 
-        public X509Certificate2  CreateNamedKeyCertificate(CertData data)
+        public X509Certificate2 CreateNamedKeyCertificate(CertData data)
         {
             try
             {
                 CngKeyCreationParameters keyCreationParameters
                     = new CngKeyCreationParameters
-                          {
-                              ExportPolicy =
+                    {
+                        ExportPolicy =
                                   CngExportPolicies.AllowExport |
                                   CngExportPolicies.AllowPlaintextExport |
                                   CngExportPolicies.AllowPlaintextArchiving |
                                   CngExportPolicies.AllowArchiving,
-                              KeyUsage = CngKeyUsages.AllUsages
-                          };
+                        KeyUsage = CngKeyUsages.AllUsages
+                    };
 
                 X509Certificate2 cert;
                 X509CertificateCreationParameters configCreate
                     = new X509CertificateCreationParameters(new X500DistinguishedName(data.DistinguishedName))
-                          {
-                              EndTime =
+                    {
+                        EndTime =
                                   DateTime.Parse("01/01/2020",
                                                  System.Globalization.
                                                      DateTimeFormatInfo.
                                                      InvariantInfo),
-                              StartTime =
+                        StartTime =
                                   DateTime.Parse("01/01/2010",
                                                  System.Globalization.
                                                      DateTimeFormatInfo.
                                                      InvariantInfo)
-                          };
+                    };
 
                 using (CngKey namedKey = CngKey.Create(CngAlgorithm2.Rsa, data.Key, keyCreationParameters))
                 {

--- a/csharp/unittests/common/Certificates/CertificateFacts.cs
+++ b/csharp/unittests/common/Certificates/CertificateFacts.cs
@@ -11,19 +11,14 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
-using System.Linq;
-using System.Net.Mail;
-using System.IO;
+
 using System.Security.Cryptography;
-using Health.Direct.Common.Cryptography;
-using Health.Direct.Common.Certificates;
-using Health.Direct.Common.Extensions;
 using System.Xml.Serialization;
+using Health.Direct.Common.Certificates;
+using Health.Direct.Common.Cryptography;
+using Health.Direct.Common.Extensions;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Certificates
 {
@@ -38,21 +33,21 @@ namespace Health.Direct.Common.Tests.Certificates
                 new Oid(SMIMECryptographer.CryptoOids.SHA256.Value, "SHA256 Digest Algorithm"),
             };
             metadata.BundleSource = "Toby's bundle";
-            
+
             string xml = null;
-            Assert.DoesNotThrow(() => xml = metadata.ToXml());
-            
+            Assert.Null(Record.Exception(() => xml = metadata.ToXml()));
+
             AnchorMetadata metadataParsed = null;
-            Assert.DoesNotThrow(() => metadataParsed = (AnchorMetadata) new XmlSerializer(typeof(AnchorMetadata)).FromXml(xml));
-            
+            Assert.Null(Record.Exception(() => metadataParsed = (AnchorMetadata)new XmlSerializer(typeof(AnchorMetadata)).FromXml(xml)));
+
             Assert.True(metadataParsed.HasRequiredOids);
-            Assert.True(metadata.RequiredOids.Length == metadataParsed.RequiredOids.Length);            
+            Assert.True(metadata.RequiredOids.Length == metadataParsed.RequiredOids.Length);
             for (int i = 0; i < metadata.RequiredOids.Length; ++i)
             {
                 Assert.Equal(metadata.RequiredOids[i].Value, metadataParsed.RequiredOids[i].Value);
                 Assert.Equal(metadata.RequiredOids[i].FriendlyName, metadataParsed.RequiredOids[i].FriendlyName);
             }
-            
+
             Assert.Equal(metadata.BundleSource, metadataParsed.BundleSource);
         }
     }

--- a/csharp/unittests/common/Certificates/CertificateResolverBasic.cs
+++ b/csharp/unittests/common/Certificates/CertificateResolverBasic.cs
@@ -11,19 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
+
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Mail;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
 using Health.Direct.Common.Certificates;
-using Health.Direct.Common.Caching;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Certificates
 {

--- a/csharp/unittests/common/Certificates/CertificateResolverFacts.cs
+++ b/csharp/unittests/common/Certificates/CertificateResolverFacts.cs
@@ -11,32 +11,29 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
-
-using Health.Direct.Common.Certificates;
 using Health.Direct.Common.Caching;
+using Health.Direct.Common.Certificates;
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Certificates
 {
     public class CertificateResolverFacts : IDisposable
     {
-        const string TestCacheName = "Cert.testcache"; 
+        const string TestCacheName = "Cert.testcache";
         const string DomainIncubator = "nhind.hsgincubator.com";
         const string UserAtDomainIncubator = "user@nhind.hsgincubator.com";
-        const string DomainNotExists = "blahblahabcd.com";       
+        const string DomainNotExists = "blahblahabcd.com";
 
         string[] m_domains = new string[] { DomainIncubator, UserAtDomainIncubator, DomainNotExists };
 
-        SystemX509Store m_certStore; 
+        SystemX509Store m_certStore;
         CertificateResolver m_resolver;
         CertificateCache m_cache;
         bool m_negativeCache;
@@ -47,7 +44,7 @@ namespace Health.Direct.Common.Tests.Certificates
 
             m_cache = m_resolver.Cache;
 
-            ClearCache();            
+            ClearCache();
         }
 
         [Fact]
@@ -59,10 +56,10 @@ namespace Health.Direct.Common.Tests.Certificates
                 NegativeCache = true,
                 CacheTTLSeconds = 60,
                 Name = "ABC"
-            }; 
+            };
 
             Assert.Throws(typeof(InvalidOperationException), () => settings.Validate());
-            Assert.Throws(typeof(InvalidOperationException), () => new CertificateCache(settings)); 
+            Assert.Throws(typeof(InvalidOperationException), () => new CertificateCache(settings));
         }
 
         [Fact]
@@ -72,19 +69,19 @@ namespace Health.Direct.Common.Tests.Certificates
             X509Certificate2Collection source = m_resolver.GetCertificatesForDomain(domain);
             X509Certificate2Collection cached = m_cache.Get(domain);
 
-            VerifyValidCert(source, cached);            
+            VerifyValidCert(source, cached);
 
             // now get it served from the cache. 
             source = m_resolver.GetCertificatesForDomain(domain);
             cached = m_cache.Get(domain);
 
-            VerifyValidCert(source, cached);            
+            VerifyValidCert(source, cached);
         }
 
         [Fact]
         public void CachingCertNotFoundNoNegativeCache()
         {
-            CachingCertNotFound(); 
+            CachingCertNotFound();
         }
 
         [Fact]
@@ -116,7 +113,7 @@ namespace Health.Direct.Common.Tests.Certificates
                 true,   /* caching enabled */
                 3,      /* TTL */
                 false); /* negative cache */
-                
+
             string domain = DomainIncubator;
             X509Certificate2Collection source = m_resolver.GetCertificatesForDomain(domain);
             X509Certificate2Collection cached = m_cache.Get(domain);
@@ -149,7 +146,7 @@ namespace Health.Direct.Common.Tests.Certificates
             X509Certificate2Collection cached = m_cache.Get(domain);
 
             Assert.Null(cached);
-            Assert.True(source.Count > 0); 
+            Assert.True(source.Count > 0);
         }
 
         [Fact]
@@ -157,7 +154,7 @@ namespace Health.Direct.Common.Tests.Certificates
         {
             using (SystemX509Store store = SystemX509Store.OpenExternal())
             {
-                m_resolver = new CertificateResolver(store, null);                
+                m_resolver = new CertificateResolver(store, null);
                 m_cache = m_resolver.Cache;
                 string domain = DomainIncubator;
                 X509Certificate2Collection source = m_resolver.GetCertificatesForDomain(domain);
@@ -175,23 +172,23 @@ namespace Health.Direct.Common.Tests.Certificates
             X509Certificate2Collection cached = m_cache.Get(domain);
 
             VerifyValidCert(source, cached);
-                         
-            domain = DomainIncubator.ToUpper(); 
+
+            domain = DomainIncubator.ToUpper();
             source = m_resolver.GetCertificatesForDomain(domain);
             cached = m_cache.Get(domain);
 
-            VerifyValidCert(source, cached);            
+            VerifyValidCert(source, cached);
         }
 
         [Fact]
         public void CachingVerifyFallbackAddressesNoNegativeCache()
-        {   
+        {
             CachingVerifyFallbackAddresses();
         }
 
         [Fact]
         public void CachingVerifyFallbackAddressesNegativeCache()
-        {   
+        {
             m_resolver = CreateResolver(true, 60, true);
             CachingVerifyFallbackAddresses();
         }
@@ -221,7 +218,7 @@ namespace Health.Direct.Common.Tests.Certificates
         {
             if (m_certStore != null)
             {
-                m_certStore.Dispose(); 
+                m_certStore.Dispose();
             }
 
             m_certStore = SystemX509Store.OpenExternal();
@@ -229,11 +226,13 @@ namespace Health.Direct.Common.Tests.Certificates
 
             return new CertificateResolver(
                 m_certStore,
-                new CacheSettings() { 
-                    Name = TestCacheName, 
-                    Cache = cachingEnabled, 
+                new CacheSettings()
+                {
+                    Name = TestCacheName,
+                    Cache = cachingEnabled,
                     NegativeCache = negativeCache,
-                    CacheTTLSeconds = ttlSeconds});
+                    CacheTTLSeconds = ttlSeconds
+                });
         }
 
         public void Dispose()
@@ -247,10 +246,10 @@ namespace Health.Direct.Common.Tests.Certificates
         private void ClearCache()
         {
             // clear the cache store. 
-            Cache<X509Certificate2Collection> cache = new Cache<X509Certificate2Collection>(TestCacheName);             
+            Cache<X509Certificate2Collection> cache = new Cache<X509Certificate2Collection>(TestCacheName);
             foreach (string domain in m_domains)
             {
-                cache.Remove(domain);                
+                cache.Remove(domain);
             }
         }
 
@@ -276,7 +275,7 @@ namespace Health.Direct.Common.Tests.Certificates
             }
             else
             {
-                Assert.Null(cached); 
+                Assert.Null(cached);
             }
         }
     }

--- a/csharp/unittests/common/Collection/PropertyFacts.cs
+++ b/csharp/unittests/common/Collection/PropertyFacts.cs
@@ -11,12 +11,10 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
+
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 using Health.Direct.Common.Collections;
 using Health.Direct.Common.Extensions;
@@ -29,7 +27,7 @@ namespace Health.Direct.Common.Tests.Collection
         public PropertyFacts()
         {
         }
-        
+
         public IEnumerable<KeyValuePair<string, string>> Pairs
         {
             get
@@ -41,22 +39,22 @@ namespace Health.Direct.Common.Tests.Collection
                 }
             }
         }
-        
+
         [Fact]
         public void BagSerializeText()
         {
             PropertyBag bag = this.CreateBag();
-            
+
             XmlSerializer serializer = new XmlSerializer(typeof(PropertyBag));
             string xml = null;
-            
-            Assert.DoesNotThrow(() => xml = serializer.ToXml(bag));            
+
+            Assert.Null(Record.Exception(() => xml = serializer.ToXml(bag)));
             Assert.True(!string.IsNullOrEmpty(xml));
-            
+
             PropertyBag bag2 = null;
-            Assert.DoesNotThrow(() => bag2 = (PropertyBag) serializer.FromXml(xml));
+            Assert.Null(Record.Exception(() => bag2 = (PropertyBag)serializer.FromXml(xml)));
             Assert.NotNull(bag2);
-            
+
             Assert.True(Compare(bag, bag2));
         }
 
@@ -68,11 +66,11 @@ namespace Health.Direct.Common.Tests.Collection
             XmlSerializer serializer = new XmlSerializer(typeof(PropertyBag));
             byte[] xml = null;
 
-            Assert.DoesNotThrow(() => xml = serializer.ToBytes(bag));
+            Assert.Null(Record.Exception(() => xml = serializer.ToBytes(bag)));
             Assert.True(!xml.IsNullOrEmpty());
 
             PropertyBag bag2 = null;
-            Assert.DoesNotThrow(() => bag2 = (PropertyBag)serializer.FromBytes(xml));
+            Assert.Null(Record.Exception(() => bag2 = (PropertyBag)serializer.FromBytes(xml)));
             Assert.NotNull(bag2);
 
             Assert.True(Compare(bag, bag2));
@@ -86,11 +84,11 @@ namespace Health.Direct.Common.Tests.Collection
             XmlSerializer serializer = new XmlSerializer(typeof(PropertySet));
             string xml = null;
 
-            Assert.DoesNotThrow(() => xml = serializer.ToXml(set));
+            Assert.Null(Record.Exception(() => xml = serializer.ToXml(set)));
             Assert.True(!string.IsNullOrEmpty(xml));
 
             PropertySet set2 = null;
-            Assert.DoesNotThrow(() => set2 = (PropertySet) serializer.FromXml(xml));
+            Assert.Null(Record.Exception(() => set2 = (PropertySet)serializer.FromXml(xml)));
             Assert.NotNull(set2);
 
             Assert.True(Compare(set, set2));
@@ -104,28 +102,28 @@ namespace Health.Direct.Common.Tests.Collection
             XmlSerializer serializer = new XmlSerializer(typeof(PropertyBag));
             byte[] xml = null;
 
-            Assert.DoesNotThrow(() => xml = serializer.ToBytes(bag));
+            Assert.Null(Record.Exception(() => xml = serializer.ToBytes(bag)));
             Assert.True(!xml.IsNullOrEmpty());
 
             PropertyBag bag2 = null;
-            Assert.DoesNotThrow(() => bag2 = (PropertyBag)serializer.FromBytes(xml));
+            Assert.Null(Record.Exception(() => bag2 = (PropertyBag)serializer.FromBytes(xml)));
             Assert.NotNull(bag2);
 
             Assert.True(Compare(bag, bag2));
         }
-        
+
         PropertyBag CreateBag()
         {
             PropertyBag bag = new PropertyBag(this.Pairs);
             return bag;
         }
-        
+
         PropertySet CreateSet()
         {
             PropertySet set = new PropertySet(this.Pairs);
             return set;
         }
-        
+
         bool Compare(PropertyBag x, PropertyBag y)
         {
             var common = Common(x, y);
@@ -137,7 +135,7 @@ namespace Health.Direct.Common.Tests.Collection
             var common = Common(x, y);
             return (x.Count == common.Count());
         }
-        
+
         IEnumerable<KeyValuePair<string, string>> Common(PropertyBag x, PropertyBag y)
         {
             return Common(x.KeyValuePairs, y.KeyValuePairs);

--- a/csharp/unittests/common/Container/PluginFacts.cs
+++ b/csharp/unittests/common/Container/PluginFacts.cs
@@ -11,18 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+
+using System.IO;
 using System.Xml.Serialization;
 using Health.Direct.Common.Container;
 using Health.Direct.Common.Extensions;
-using System.IO;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Container
 {
@@ -56,7 +51,7 @@ namespace Health.Direct.Common.Tests.Container
             using (StringReader reader = new StringReader(PluginXml))
             {
                 DummyPluginContainer container = null;
-                Assert.DoesNotThrow(() => container = (DummyPluginContainer)serializer.Deserialize(reader));
+                Assert.Null(Record.Exception(() => container = (DummyPluginContainer)serializer.Deserialize(reader)));
                 Assert.False(container.Plugins.IsNullOrEmpty());
                 foreach (PluginDefinition def in container.Plugins)
                 {
@@ -70,7 +65,7 @@ namespace Health.Direct.Common.Tests.Container
         void VerifyDummy(PluginDefinition def, string expectedName)
         {
             DummyPlugin plugin = null;
-            Assert.DoesNotThrow(() => plugin = def.Create<DummyPlugin>());
+            Assert.Null(Record.Exception(() => plugin = def.Create<DummyPlugin>()));
             Assert.True(plugin.Settings != null);
             Assert.True(plugin.Settings.FirstName == expectedName);
         }
@@ -106,7 +101,7 @@ namespace Health.Direct.Common.Tests.Container
         }
         public void Init(PluginDefinition pluginDef)
         {
-            Assert.DoesNotThrow(() => this.Settings = pluginDef.DeserializeSettings<DummySettings>());
+            Assert.Null(Record.Exception(() => this.Settings = pluginDef.DeserializeSettings<DummySettings>()));
         }
     }
 }

--- a/csharp/unittests/common/Container/SimpleContainerSectionFacts.cs
+++ b/csharp/unittests/common/Container/SimpleContainerSectionFacts.cs
@@ -11,15 +11,12 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
 
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
-
 using Health.Direct.Common.Container;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Container
@@ -50,10 +47,10 @@ namespace Health.Direct.Common.Tests.Container
         public void CreateInstance()
         {
             var component = SectionHasComponent();
-            
+
             Assert.Equal(typeof(IFoo), component.ServiceType);
 
-            object instance  = component.CreateInstance();
+            object instance = component.CreateInstance();
             Assert.IsType(typeof(Foo), instance);
         }
 
@@ -85,7 +82,6 @@ namespace Health.Direct.Common.Tests.Container
             var bar2 = container.Resolve<IBar>();
             Assert.NotSame(bar, bar2);
         }
-
 
         [Fact]
         public void RegisterMultipleComponentsWithSameServiceType()

--- a/csharp/unittests/common/Diagnostics/AuditFacts.cs
+++ b/csharp/unittests/common/Diagnostics/AuditFacts.cs
@@ -11,15 +11,10 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+
 using Health.Direct.Common.Diagnostics;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Diagnostics
 {
@@ -28,7 +23,7 @@ namespace Health.Direct.Common.Tests.Diagnostics
         public AuditFacts()
         {
         }
-        
+
         [Fact]
         public void TestMessage()
         {

--- a/csharp/unittests/common/Diagnostics/RolloverFacts.cs
+++ b/csharp/unittests/common/Diagnostics/RolloverFacts.cs
@@ -1,9 +1,22 @@
-﻿using System;
+﻿/* 
+ Copyright (c) 2010, Direct Project
+ All rights reserved.
+
+ Authors:
+    Umesh Madan     umeshma@microsoft.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+using System;
 using System.IO;
 using System.Threading;
-
 using Health.Direct.Common.Diagnostics;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Diagnostics

--- a/csharp/unittests/common/Mail/MailMessageGenerator.cs
+++ b/csharp/unittests/common/Mail/MailMessageGenerator.cs
@@ -11,18 +11,14 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Net.Mail;
 using System.Net.Mime;
 using System.Text;
-using System.Net.Mail;
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mime;
-using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mail
 {
@@ -121,7 +117,5 @@ namespace Health.Direct.Common.Tests.Mail
 
             return wrapped;
         }
-
-
     }
 }

--- a/csharp/unittests/common/Mail/MailParserFacts.cs
+++ b/csharp/unittests/common/Mail/MailParserFacts.cs
@@ -11,16 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Linq;
-using System.Net.Mail;
-using System.IO;
 using System.Collections.ObjectModel;
+using System.Net.Mail;
 using Health.Direct.Common.Mail;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mail
 {
@@ -89,12 +86,12 @@ Yo. Wassup?";
             Message message = null;
             string headerValue = null;
 
-            Assert.DoesNotThrow(() => message = Message.Load(MailParserFacts.TestMessage));
+            Assert.Null(Record.Exception(() => message = Message.Load(MailParserFacts.TestMessage)));
             Assert.NotNull(message);
 
-            Assert.DoesNotThrow(() => headerValue = message.ToValue);
-            Assert.DoesNotThrow(() => headerValue = message.SubjectValue);
-            Assert.DoesNotThrow(() => headerValue = message.DateValue);
+            Assert.Null(Record.Exception(() => headerValue = message.ToValue));
+            Assert.Null(Record.Exception(() => headerValue = message.SubjectValue));
+            Assert.Null(Record.Exception(() => headerValue = message.DateValue));
         }
 
         public static string TestMessageNoSubject =
@@ -124,14 +121,14 @@ Yo. Wassup?";
             Message message = null;
             string headerValue = null;
 
-            Assert.DoesNotThrow(() => message = Message.Load(MailParserFacts.TestMessageNoSubject));
+            Assert.Null(Record.Exception(() => message = Message.Load(MailParserFacts.TestMessageNoSubject)));
             Assert.NotNull(message);
-            Assert.DoesNotThrow(() => headerValue = message.SubjectValue);
+            Assert.Null(Record.Exception(() => headerValue = message.SubjectValue));
             Assert.True(headerValue == null);
 
-            Assert.DoesNotThrow(() => message = Message.Load(MailParserFacts.TestMessageEmptySubject));
+            Assert.Null(Record.Exception(() => message = Message.Load(MailParserFacts.TestMessageEmptySubject)));
             Assert.NotNull(message);
-            Assert.DoesNotThrow(() => headerValue = message.SubjectValue);
+            Assert.Null(Record.Exception(() => headerValue = message.SubjectValue));
             Assert.True(string.IsNullOrEmpty(headerValue));
         }
     }

--- a/csharp/unittests/common/Mail/MailSerializationFacts.cs
+++ b/csharp/unittests/common/Mail/MailSerializationFacts.cs
@@ -11,17 +11,12 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Net.Mail;
 using Health.Direct.Common.Mail;
-using Health.Direct.Common.Mime;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mail
 {
@@ -44,17 +39,17 @@ namespace Health.Direct.Common.Tests.Mail
         public void TestAddressCollectionFolding(int addressCount, string source)
         {
             MailAddressCollection addresses = null;
-            Assert.DoesNotThrow(() => addresses = MailParser.ParseAddressCollection(source));
+            Assert.Null(Record.Exception(() => addresses = MailParser.ParseAddressCollection(source)));
 
             string foldedText = null;
-            Assert.DoesNotThrow(() => foldedText = addresses.ToStringWithFolding());
+            Assert.Null(Record.Exception(() => foldedText = addresses.ToStringWithFolding()));
             Assert.True(!string.IsNullOrEmpty(foldedText));
 
             string[] foldedParts = null;
-            Assert.DoesNotThrow(() => foldedParts = foldedText.Split(new string[] { MailStandard.CRLF}, StringSplitOptions.None));
+            Assert.Null(Record.Exception(() => foldedParts = foldedText.Split(new string[] { MailStandard.CRLF }, StringSplitOptions.None)));
             this.CheckParts(foldedParts, addressCount);
         }
-        
+
         void CheckParts(string[] foldedParts, int addressCount)
         {
             Assert.True(foldedParts.Length == addressCount);
@@ -65,7 +60,7 @@ namespace Health.Direct.Common.Tests.Mail
                 Assert.True(line.Length > 0);
                 Assert.True(line.Length < MailStandard.MaxCharsInLine);
                 if (i > 0)
-                {   
+                {
                     // Verify starts with whitespace
                     Assert.True(MailStandard.IsWhitespace(line[0]));
                 }
@@ -74,6 +69,6 @@ namespace Health.Direct.Common.Tests.Mail
                     Assert.True(line[line.Length - 1] == ',');
                 }
             }
-        }        
+        }
     }
 }

--- a/csharp/unittests/common/Mail/MessageIDFacts.cs
+++ b/csharp/unittests/common/Mail/MessageIDFacts.cs
@@ -11,19 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
+
 using System.Linq;
 using System.Net.Mail;
-using System.IO;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using Health.Direct.Common.Mail;
 using Health.Direct.Common.Extensions;
+using Health.Direct.Common.Mail;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mail
 {
@@ -35,30 +29,30 @@ namespace Health.Direct.Common.Tests.Mail
         public void TestID(string hostName)
         {
             string messageID = null;
-            
-            Assert.DoesNotThrow(() => messageID = Message.GenerateMessageID(hostName));
+
+            Assert.Null(Record.Exception(() => messageID = Message.GenerateMessageID(hostName)));
             Assert.True(!string.IsNullOrEmpty(messageID));
             Assert.True(messageID[0] == '<');
             Assert.True(messageID[messageID.Length - 1] == '>');
             Assert.True(messageID.Contains('@'));
-            
+
             if (string.IsNullOrEmpty(hostName))
             {
-                Assert.True(messageID.Contains(System.Net.Dns.GetHostName()));    
+                Assert.True(messageID.Contains(System.Net.Dns.GetHostName()));
             }
             else
             {
                 Assert.True(messageID.Contains(hostName));
             }
         }
-        
+
         [Fact]
         public void TestMessage()
         {
             Message message = new Message();
             message.FromValue = "toby@redmond.hsgincubator.com";
-            Assert.DoesNotThrow(() => message.AssignMessageID());
-            
+            Assert.Null(Record.Exception(() => message.AssignMessageID()));
+
             string messageID = message.IDValue;
             MailAddress address = new MailAddress(message.FromValue);
             Assert.True(messageID.Contains(address.Host));

--- a/csharp/unittests/common/Mail/RFC822DateFacts.cs
+++ b/csharp/unittests/common/Mail/RFC822DateFacts.cs
@@ -11,27 +11,20 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Globalization;
-using System.Linq;
-using System.Net.Mail;
-using System.IO;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Threading;
-using Health.Direct.Common.Mail;
+using System.Linq;
 using Health.Direct.Common.Extensions;
+using Health.Direct.Common.Mail;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mail
 {
     public class RFC822DateFacts
     {
-        static string[] DayNames = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+        static string[] DayNames = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
         static string[] MonthNames = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 
         public static IEnumerable<object[]> Dates
@@ -41,7 +34,7 @@ namespace Health.Direct.Common.Tests.Mail
                 DateTime now = DateTime.Now;
                 for (int i = 0; i < 7; ++i)
                 {
-                    yield return new object[] { now.AddDays(i)};
+                    yield return new object[] { now.AddDays(i) };
                 }
             }
         }
@@ -57,69 +50,69 @@ namespace Health.Direct.Common.Tests.Mail
                 }
             }
         }
-        
+
         [Theory]
-        [PropertyData("Dates")]
+        [MemberData("Dates", DisableDiscoveryEnumeration = true)]
         public void TestDateSerialization(DateTime now)
         {
             string dateString = null;
-            Assert.DoesNotThrow(() => dateString = now.ToRFC822String());
+            Assert.Null(Record.Exception(() => dateString = now.ToRFC822String()));
             Assert.True(!string.IsNullOrEmpty(dateString));
         }
 
         [Theory]
-        [PropertyData("Dates")]
+        [MemberData("Dates", DisableDiscoveryEnumeration = true)]
         public void TestDayName(DateTime now)
         {
             string dateString = null;
             string dayName = null;
-            
-            Assert.DoesNotThrow(() => dateString = now.ToRFC822String());
-            
-            Assert.DoesNotThrow(() => dayName = dateString.Substring(0, dateString.IndexOf(',')));   
+
+            Assert.Null(Record.Exception(() => dateString = now.ToRFC822String()));
+
+            Assert.Null(Record.Exception(() => dayName = dateString.Substring(0, dateString.IndexOf(','))));
             Assert.True(RFC822DateFacts.DayNames.Contains(dayName));
         }
 
         [Theory]
-        [PropertyData("Months")]
+        [MemberData("Months", DisableDiscoveryEnumeration = true)]
         public void TestMonth(DateTime now)
         {
             string dateString = null;
 
-            Assert.DoesNotThrow(() => dateString = now.ToRFC822String());
+            Assert.Null(Record.Exception(() => dateString = now.ToRFC822String()));
             Assert.True(this.FindMonth(dateString));
         }
 
         [Theory]
-        [PropertyData("Dates")]
+        [MemberData("Dates", DisableDiscoveryEnumeration = true)]
         public void TestZone(DateTime now)
         {
             string dateString = null;
 
-            Assert.DoesNotThrow(() => dateString = now.ToRFC822String());
+            Assert.Null(Record.Exception(() => dateString = now.ToRFC822String()));
             Console.WriteLine(dateString);
             int indexOfDash = -1;
-            Assert.DoesNotThrow(() => indexOfDash = dateString.LastIndexOf('-'));
+            Assert.Null(Record.Exception(() => indexOfDash = dateString.LastIndexOf('-')));
             if (indexOfDash == -1)
             {
                 indexOfDash = dateString.LastIndexOf('+');
             }
             Assert.True(indexOfDash >= 0);
-            
+
             // Verify there is no colon after the dash or plus
             Assert.True(dateString.IndexOf(':', indexOfDash) < 0);
         }
 
         [Theory]
-        [PropertyData("Dates")]
+        [MemberData("Dates", DisableDiscoveryEnumeration = true)]
         public void TestZoneUtc(DateTime now)
         {
             string dateString = null;
 
-            Assert.DoesNotThrow(() => dateString = now.ToUniversalTime().ToRFC822String());
+            Assert.Null(Record.Exception(() => dateString = now.ToUniversalTime().ToRFC822String()));
             Console.WriteLine(dateString);
             int indexOfDash = -1;
-            Assert.DoesNotThrow(() => indexOfDash = dateString.LastIndexOf('-'));
+            Assert.Null(Record.Exception(() => indexOfDash = dateString.LastIndexOf('-')));
             if (indexOfDash == -1)
             {
                 indexOfDash = dateString.LastIndexOf('+');
@@ -130,22 +123,18 @@ namespace Health.Direct.Common.Tests.Mail
             Assert.True(dateString.IndexOf(':', indexOfDash) < 0);
         }
 
-
-
-
-       
         [Fact]
         public void TestMessage()
         {
             Message message = new Message();
-            Assert.DoesNotThrow(() => message.Timestamp());
-            
+            Assert.Null(Record.Exception(() => message.Timestamp()));
+
             string dateValue = null;
-            Assert.DoesNotThrow(() => dateValue = message.DateValue);
+            Assert.Null(Record.Exception(() => dateValue = message.DateValue));
             Assert.True(!string.IsNullOrEmpty(dateValue));
             Assert.True(this.FindMonth(dateValue));
         }
-                        
+
         bool FindMonth(string dateString)
         {
             for (int i = 0; i < MonthNames.Length; ++i)
@@ -162,7 +151,7 @@ namespace Health.Direct.Common.Tests.Mail
                     return true;
                 }
             }
-            
+
             return false;
         }
     }

--- a/csharp/unittests/common/Mail/RoundTripFacts.cs
+++ b/csharp/unittests/common/Mail/RoundTripFacts.cs
@@ -11,14 +11,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
 
 using System.Linq;
-
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mail
@@ -48,7 +45,7 @@ namespace Health.Direct.Common.Tests.Mail
             Assert.Equal("drsmith@exchange.example.org", m2.To.Value);
             Assert.Equal("Hello, world!", m2.Subject.Value);
         }
-        
+
         /// <summary>
         /// Basic round trip mutipart message - treat as a value object in tests -- no modifying...
         /// </summary>
@@ -74,13 +71,11 @@ namespace Health.Direct.Common.Tests.Mail
             }
         }
 
-
-
         [Fact]
         public void RoundTripMultipartEmailShouldBeMultipart()
         {
             Message m = RoundTripMultipartMessage;
-            Assert.True(m.IsMultiPart);    
+            Assert.True(m.IsMultiPart);
         }
 
         [Fact]
@@ -111,7 +106,7 @@ namespace Health.Direct.Common.Tests.Mail
                              .ElementAt(1)
                              .Body.Text);
         }
-        
+
         [Fact]
         public void CheckDate()
         {
@@ -119,7 +114,7 @@ namespace Health.Direct.Common.Tests.Mail
             m.To = new Header("To", "drsmith@exchange.example.org");
             m.Subject = new Header("Subject", "Hello, world!");
             m.Body = new Body("This is a test.");
-            
+
             m.Timestamp();
             Assert.True(m.HasHeader(MailStandard.Headers.Date));
 

--- a/csharp/unittests/common/Mail/TestDSN.cs
+++ b/csharp/unittests/common/Mail/TestDSN.cs
@@ -11,8 +11,8 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -32,8 +32,6 @@ namespace Health.Direct.Common.Tests.Mail
         const string OriginalID = "Message In a Bottle";
         const string Postmaster = "postmaster@redmond.hsgincubator.com";
         const string Subject = "Sound Grenade";
-
-       
 
         [Fact]
         public void TestFailedDeliveryStatusNotification()
@@ -142,7 +140,7 @@ Status: 5.0.0
         public void TestFailedDeliveryStatusSerialization()
         {
             Message source = this.CreateSourceMessage();
-            
+
             DSN dsnExpected = this.CreateFailedStatusNotification(3);
             DSNMessage dsnMessage = source.CreateStatusMessage(new MailAddress(Postmaster), dsnExpected);
             Console.WriteLine(dsnMessage);
@@ -158,7 +156,7 @@ Status: 5.0.0
                 Assert.True(loadedMessage.HasHeader(MailStandard.Headers.Date));
                 Assert.True(loadedMessage.Headers.Count(x => (MimeStandard.Equals(x.Name, MimeStandard.VersionHeader))) == 1);
                 var dsnActual = DSNParser.Parse(loadedMessage);
-                
+
                 VerifyEqual(dsnExpected, dsnActual);
             }
             finally
@@ -179,7 +177,6 @@ Status: 5.0.0
             Assert.Equal(dsnExpected.PerRecipient.First().Status, dsnActual.PerRecipient.First().Status);
         }
 
-
         /// <summary>
         /// Verify Disposition-Type MDN notification 
         /// </summary>
@@ -196,13 +193,13 @@ Status: 5.0.0
             //
             // perRecipient
             //
-            Assert.True(fields.HasHeader(DSNStandard.Fields.FinalRecipient, 
+            Assert.True(fields.HasHeader(DSNStandard.Fields.FinalRecipient,
                                          "rfc822;" + notification.PerRecipient.First().FinalRecipient.Address));
             Assert.True(fields.HasHeader(DSNStandard.Fields.Action, "failed"));
             Assert.True(fields.HasHeader(DSNStandard.Fields.Status, "5.0.0"));
-            
+
         }
-              
+
         DSN CreateFailedStatusNotification()
         {
             return CreateFailedStatusNotification(1);
@@ -219,9 +216,9 @@ Status: 5.0.0
                 perRecipients.Add(new DSNPerRecipient(DSNStandard.DSNAction.Failed, DSNStandard.DSNStatus.Permanent
                                                       , DSNStandard.DSNStatus.UNDEFINED_STATUS,
                                                       new MailAddress(String.Format("User{0}@kryptiq.com", i))));
-                
+
             }
-            
+
             var dsn = new DSN(perMessage, perRecipients);
 
             return dsn;
@@ -254,6 +251,5 @@ Status: 5.0.0
             Assert.True(dsnEntities[0].ParsedContentType.IsMediaType(DSNStandard.MediaType.TextPlain));
             Assert.True(dsnEntities[1].ParsedContentType.IsMediaType(DSNStandard.MediaType.DSNDeliveryStatus));
         }
-
     }
 }

--- a/csharp/unittests/common/Mail/TestMDN.cs
+++ b/csharp/unittests/common/Mail/TestMDN.cs
@@ -12,18 +12,16 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Mail;
-using System.IO;
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mail.Notifications;
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mail
@@ -44,10 +42,10 @@ namespace Health.Direct.Common.Tests.Mail
 
             disposition = new Disposition(MDNStandard.NotificationType.Processed, true);
             Assert.True(disposition.ToString() == "automatic-action/MDN-sent-automatically;processed/error");
-                        
+
             disposition = new Disposition(MDNStandard.TriggerType.Automatic, MDNStandard.SendType.UserMediated, MDNStandard.NotificationType.Displayed, true);
             Assert.True(disposition.ToString() == "automatic-action/MDN-sent-manually;displayed/error");
-            
+
             disposition = new Disposition(MDNStandard.TriggerType.UserInitiated, MDNStandard.SendType.UserMediated, MDNStandard.NotificationType.Displayed, true);
             Assert.True(disposition.ToString() == "manual-action/MDN-sent-manually;displayed/error");
         }
@@ -55,7 +53,7 @@ namespace Health.Direct.Common.Tests.Mail
         const string OriginalID = "Message In a Bottle";
         const string ErrorMessage = "Bring on The Night";
         const string NotificationExplanation = "Synchronicity";
-        
+
         [Fact]
         public void TestNotification_AssertProcessed()
         {
@@ -66,16 +64,16 @@ namespace Health.Direct.Common.Tests.Mail
             Notification notificationActual = this.CreateProcessedNotification();
 
 
-            MimeEntity[] mdnEntities = notificationActual.ToArray();            
+            MimeEntity[] mdnEntities = notificationActual.ToArray();
             this.Verify(mdnEntities);
-            
+
             Assert.True(mdnEntities[0].Body.Text == NotificationExplanation);
 
             this.VerifyDispositionTypeNotification(mdnEntities[1], notificationExpected);
 
-            Assert.DoesNotThrow(() => notificationActual.ToEntity());
+            Assert.Null(Record.Exception(() => notificationActual.ToEntity()));
 
-            Assert.DoesNotThrow(() => MimeSerializer.Default.Serialize(notificationActual.ToEntity()));            
+            Assert.Null(Record.Exception(() => MimeSerializer.Default.Serialize(notificationActual.ToEntity())));
         }
 
         [Fact]
@@ -94,36 +92,36 @@ namespace Health.Direct.Common.Tests.Mail
 
             this.VerifyDispositionTypeNotification(mdnEntities[1], notificationExpected);
 
-            Assert.DoesNotThrow(() => notificationActual.ToEntity());
+            Assert.Null(Record.Exception(() => notificationActual.ToEntity()));
 
-            Assert.DoesNotThrow(() => MimeSerializer.Default.Serialize(notificationActual.ToEntity()));  
+            Assert.Null(Record.Exception(() => MimeSerializer.Default.Serialize(notificationActual.ToEntity())));
         }
 
         [Fact]
         public void TestProcessedNotificationMessage()
         {
             Message source = this.CreateSourceMessage();
-            
+
             Notification notification = this.CreateProcessedNotification();
             NotificationMessage notificationMessage = source.CreateNotificationMessage(new MailAddress(source.FromValue), notification);
-            
+
             Console.WriteLine(notificationMessage);
             Assert.True(notificationMessage.IsMDN());
             Assert.False(notificationMessage.ShouldIssueNotification());
-                                    
+
             Assert.True(notificationMessage.IsMultiPart);
             Assert.True(notificationMessage.ToValue == source.Headers.GetValue(MDNStandard.Headers.DispositionNotificationTo));
-            
+
             Assert.True(!string.IsNullOrEmpty(notificationMessage.SubjectValue));
-            
+
             Assert.True(notificationMessage.HasHeader(MimeStandard.VersionHeader));
             Assert.True(notificationMessage.HasHeader(MailStandard.Headers.Date));
-            
+
             MimeEntity[] mdnEntities = notificationMessage.GetParts().ToArray();
             this.Verify(mdnEntities);
-            
+
             this.VerifyDispositionTypeNotification(mdnEntities[1], notification);
-            
+
             HeaderCollection fields = this.GetNotificationFields(mdnEntities[1]);
             Assert.NotNull(fields[MDNStandard.Fields.FinalRecipient]);
         }
@@ -155,7 +153,6 @@ namespace Health.Direct.Common.Tests.Mail
             HeaderCollection fields = this.GetNotificationFields(mdnEntities[1]);
             Assert.NotNull(fields[MDNStandard.Fields.FinalRecipient]);
         }
-            
 
         [Fact]
         public void TestNotificationOnNotication_Processed()
@@ -190,10 +187,10 @@ namespace Health.Direct.Common.Tests.Mail
         {
             Disposition expectedDisposition = new Disposition(MDNStandard.NotificationType.Processed);
 
-            Message source = this.CreateSourceMessage();            
+            Message source = this.CreateSourceMessage();
             Notification notification = this.CreateProcessedNotification();
             NotificationMessage notificationMessage = source.CreateNotificationMessage(new MailAddress(source.FromValue), notification);
-            
+
             var path = Path.GetTempFileName();
             try
             {
@@ -247,8 +244,6 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             Assert.Equal("processed", mdn.Disposition.Notification.ToString(), StringComparer.OrdinalIgnoreCase);
         }
 
-
-        
         [Fact]
         public void TestDispositionTypeFormats()
         {
@@ -256,20 +251,20 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             // Only testing ability to read untrimmed disposition types.
             //
 
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed /error "));
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; failed /error "));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed /error ")));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; failed /error ")));
 
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed / error "));
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; failed / error "));
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed / anything "));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed / error ")));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; failed / error ")));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed / anything ")));
 
             //normal
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed/modifier1,modifier2 "));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed/modifier1,modifier2 ")));
             //forgiving...
-            Assert.DoesNotThrow(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed / modifier1 , modifier2 "));
+            Assert.Null(Record.Exception(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; processed / modifier1 , modifier2 ")));
 
-            Assert.Throws <MDNException>(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; fallen / error "));
-            
+            Assert.Throws<MDNException>(() => MDNParser.ParseDisposition("automatic-action/MDN-sent-automatically; fallen / error "));
+
         }
 
         [Fact]
@@ -300,13 +295,13 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
                 File.Delete(path);
             }
         }
-                
+
         [Fact]
         public void TestParser_Processed()
         {
             Notification notification = this.CreateProcessedNotification();
             notification.OriginalRecipient = new MailAddress("original@nhind.hsgincubator.com");
-            notification.Error = "Whoops!";            
+            notification.Error = "Whoops!";
             this.SendAndParse(notification);
         }
 
@@ -346,14 +341,14 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
         public void TestAck_Processed()
         {
             Message message = this.CreateSourceMessage();
-            
+
             Notification ack = null;
-            Assert.DoesNotThrow(() => ack = Notification.CreateAck(new ReportingUserAgent("Unit Tester", "The Direct Project"), 
-                                                                   "Cheers", MDNStandard.NotificationType.Processed));
+            Assert.Null(Record.Exception(() => ack = Notification.CreateAck(new ReportingUserAgent("Unit Tester", "The Direct Project"),
+                                                                   "Cheers", MDNStandard.NotificationType.Processed)));
             Assert.True(ack.Disposition.Notification == MDNStandard.NotificationType.Processed);
-            Assert.NotNull(ack.ReportingAgent);            
+            Assert.NotNull(ack.ReportingAgent);
             Assert.Equal(ack.Explanation, "Cheers");
-            
+
             SendAndParse(ack);
         }
 
@@ -366,10 +361,10 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             Notification notification = CreateProcessedNotification();
             notification.Warning = "Xunit warning";
             MimeEntity[] mimeEntities = notification.ToArray();
-            
+
             Assert.NotNull(mimeEntities);
             Assert.Equal(2, mimeEntities.Count());
-            
+
             MimeEntity bodyEntity = mimeEntities[1];
             Assert.True(bodyEntity.ContentType.StartsWith("message/disposition-notification"));
             HeaderCollection fields = this.GetNotificationFields(bodyEntity);
@@ -438,7 +433,7 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
                 Assert.True(loadedMessage.HasHeader(MimeStandard.VersionHeader));
                 Assert.True(loadedMessage.HasHeader(MailStandard.Headers.Date));
                 Assert.True(loadedMessage.Headers.Count(x => (MimeStandard.Equals(x.Name, MimeStandard.VersionHeader))) == 1);
-               
+
                 var mdn = MDNParser.Parse(loadedMessage);
                 VerifyEqual(expectedDisposition, mdn.Disposition);
                 Assert.NotNull(mdn.SpecialFields["X-Test1"]);
@@ -452,7 +447,6 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             }
         }
 
-
         [Fact]
         public void TestDispatchTimelyAndReliableExtension_AssertExtension()
         {
@@ -464,8 +458,6 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             Assert.NotNull(mdn.SpecialFields[MDNStandard.DispositionOption_TimelyAndReliable]);
         }
 
-
-
         void SendAndParse(Notification source)
         {
             Message message = this.CreateSourceMessage();
@@ -476,11 +468,11 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
         void Parse(Notification source, NotificationMessage notificationMessage)
         {
             Notification parsed = null;
-            Assert.DoesNotThrow(() => parsed = MDNParser.Parse(source));
+            Assert.Null(Record.Exception(() => parsed = MDNParser.Parse(source)));
             Assert.NotNull(parsed.Disposition);
             VerifyEqual(source, parsed);
         }
-        
+
         void VerifyEqual(Notification x, Notification y)
         {
             if (x.ReportingAgent != null)
@@ -529,37 +521,38 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             for (int i = 0; i < x.Count(); i++)
             {
                 Assert.Equal(x[i].Name, y[i].Name);
-                Assert.Equal(x[i].ValueRaw, y[i].ValueRaw );
+                Assert.Equal(x[i].ValueRaw, y[i].ValueRaw);
             }
         }
+
         void VerifyEqual(Disposition x, Disposition y)
         {
             Assert.Equal(x.TriggerType, y.TriggerType);
             Assert.Equal(x.SendType, y.SendType);
             Assert.Equal(x.Notification, y.Notification);
             Assert.Equal(x.IsError, y.IsError);
-        }        
+        }
 
         Message CreateSourceMessage()
         {
             Message source = new Message("bob@nhind.hsgincubator.com", "toby@redmond.hsgincubator.com", "Test message");
             source.Headers.Add(MDNStandard.Headers.DispositionNotificationTo, "toby@redmond.hsgincubator.com");
             source.Headers.Add(MailStandard.Headers.MessageID, OriginalID);
-            
+
             return source;
         }
-                
+
         void Verify(MimeEntity[] mdnEntities)
         {
             Assert.True(mdnEntities.Length == 2);
             Assert.True(mdnEntities[1].ParsedContentType.IsMediaType(MDNStandard.MediaType.DispositionNotification));
         }
-        
+
         Notification CreateProcessedNotification()
         {
             return CreateProcessedNotification(false);
         }
-        
+
         Notification CreateProcessedNotification(bool isError)
         {
             Notification notification = new Notification(MDNStandard.NotificationType.Processed, isError);
@@ -570,7 +563,7 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
                 notification.Error = ErrorMessage;
             }
             notification.Explanation = NotificationExplanation;
-            
+
             return notification;
         }
 
@@ -593,7 +586,6 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             return notification;
         }
 
-
         /// <summary>
         /// Verify Disposition-Type MDN notification 
         /// </summary>
@@ -602,7 +594,7 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
             HeaderCollection fields = this.GetNotificationFields(notificationEntity);
             Assert.NotEmpty(fields);
 
-            Assert.True(fields.HasHeader(MDNStandard.Fields.Disposition, notification.Disposition.ToString()), 
+            Assert.True(fields.HasHeader(MDNStandard.Fields.Disposition, notification.Disposition.ToString()),
                 string.Format("Expected a contained Disposition-Type of {0}", notification.Disposition));
             Assert.True(fields.HasHeader(MDNStandard.Fields.Gateway, "smtp;gateway.example.com"));
             Assert.True(fields.HasHeader(MDNStandard.Fields.OriginalMessageID, OriginalID));
@@ -611,10 +603,10 @@ Final-Recipient:rfc822;toby@redmond.hsgincubator.com
                 Assert.True(fields.HasHeader(MDNStandard.Fields.Error, ErrorMessage));
             }
         }
-                
+
         HeaderCollection GetNotificationFields(MimeEntity notificationEntity)
         {
             return MDNParser.ParseMDNFields(notificationEntity);
         }
-    }       
+    }
 }

--- a/csharp/unittests/common/Mail/TimelyAndReliableFacts.cs
+++ b/csharp/unittests/common/Mail/TimelyAndReliableFacts.cs
@@ -1,7 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿/* 
+ Copyright (c) 2010, Direct Project
+ All rights reserved.
+
+ Authors:
+    Umesh Madan     umeshma@microsoft.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mail.Notifications;
 using Health.Direct.Common.Mime;

--- a/csharp/unittests/common/Mail/WrappedMessageFacts.cs
+++ b/csharp/unittests/common/Mail/WrappedMessageFacts.cs
@@ -14,19 +14,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
  
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 using System.Net.Mail;
 using System.Net.Mime;
-using System.IO;
-using Health.Direct.Common.Collections;
+using Health.Direct.Common.Cryptography;
 using Health.Direct.Common.Mail;
 using Health.Direct.Common.Mime;
-using Health.Direct.Common.Cryptography;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mail
 {
@@ -45,7 +39,7 @@ namespace Health.Direct.Common.Tests.Mail
                       MailStandard.Headers.References,
                       MailStandard.Headers.Date
                   };
-        
+
         [Theory]
         [InlineData(3, 2, 250)]
         [InlineData(4, 2, 1000)]
@@ -59,9 +53,9 @@ namespace Health.Direct.Common.Tests.Mail
             string wrappedMessageText = wrappedMessage.Serialize();
 
             Message parsedMessage = null;
-            Assert.DoesNotThrow(() => parsedMessage = Message.Load(wrappedMessageText));
+            Assert.Null(Record.Exception(() => parsedMessage = Message.Load(wrappedMessageText)));
             Message extracted = null;
-            Assert.DoesNotThrow(() => extracted = WrappedMessage.ExtractInner(parsedMessage));
+            Assert.Null(Record.Exception(() => extracted = WrappedMessage.ExtractInner(parsedMessage)));
 
             string extractedBody = extracted.Body.Text;
             if (extracted.GetTransferEncoding() == TransferEncoding.QuotedPrintable)
@@ -71,7 +65,7 @@ namespace Health.Direct.Common.Tests.Mail
             }
             Assert.True(extractedBody == mail.Body);
         }
-        
+
         [Theory]
         [InlineData("Wrapped_Quoted.eml")]
         [InlineData("Wrapped_Quoted2.eml")]
@@ -83,30 +77,30 @@ namespace Health.Direct.Common.Tests.Mail
         {
             string filePath = Path.Combine("Mail\\TestFiles", fileName);
             string mailtext = File.ReadAllText(filePath);
-            
+
             Message message = null;
-            Assert.DoesNotThrow(() => message = Message.Load(mailtext));
-            
+            Assert.Null(Record.Exception(() => message = Message.Load(mailtext)));
+
             if (SMIMEStandard.IsContentMultipartSignature(message.ParsedContentType))
             {
                 SignedEntity signedEntity = null;
-                
-                Assert.DoesNotThrow(() => signedEntity = SignedEntity.Load(message));
+
+                Assert.Null(Record.Exception(() => signedEntity = SignedEntity.Load(message)));
                 message.Headers = message.Headers.SelectNonMimeHeaders();
                 message.UpdateBody(signedEntity.Content); // this will merge in content + content specific mime headers
             }
 
             Message extracted = null;
-            Assert.DoesNotThrow(() => extracted = WrappedMessage.ExtractInner(message));
-            
+            Assert.Null(Record.Exception(() => extracted = WrappedMessage.ExtractInner(message)));
+
             Header to = null;
-            Assert.DoesNotThrow(() => to = extracted.To);
-            
+            Assert.Null(Record.Exception(() => to = extracted.To));
+
             MailAddressCollection addresses = null;
-            Assert.DoesNotThrow(() => addresses = MailParser.ParseAddressCollection(to));
+            Assert.Null(Record.Exception(() => addresses = MailParser.ParseAddressCollection(to)));
             Assert.True(addresses.Count > 0);
 
-            Assert.DoesNotThrow(() => MailParser.ParseMailAddress(extracted.From));
-        }        
+            Assert.Null(Record.Exception(() => MailParser.ParseMailAddress(extracted.From)));
+        }
     }
 }

--- a/csharp/unittests/common/Mime/BodyFacts.cs
+++ b/csharp/unittests/common/Mime/BodyFacts.cs
@@ -12,10 +12,9 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using Health.Direct.Common.Mime;
 
+using Health.Direct.Common.Mime;
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime
@@ -52,6 +51,5 @@ namespace Health.Direct.Common.Tests.Mime
             Assert.Equal(bText, b.SourceText.ToString());
             Assert.Equal(bText, b.ToString());
         }
-
     }
 }

--- a/csharp/unittests/common/Mime/CharReaderFacts.cs
+++ b/csharp/unittests/common/Mime/CharReaderFacts.cs
@@ -12,14 +12,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mime
 {
@@ -115,7 +112,7 @@ namespace Health.Direct.Common.Tests.Mime
             Assert.Equal("abc", reader.GetSegment(0, 2).ToString());
             Assert.Equal("123", reader.GetSegment(4, 6).ToString());
         }
-        
+
         [Theory]
         [InlineData("pqr\\:xyz:123")]
         [InlineData("abc\"quoted:\"pqr:123")]

--- a/csharp/unittests/common/Mime/DefaultSerializerFacts.cs
+++ b/csharp/unittests/common/Mime/DefaultSerializerFacts.cs
@@ -11,14 +11,12 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.IO;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime
@@ -98,7 +96,7 @@ namespace Health.Direct.Common.Tests.Mime
         [Fact]
         public void DeserializeThrowsArgumentNullException()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((byte[]) null));
+            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((byte[])null));
             Assert.Equal("messageBytes", ex.ParamName);
         }
 
@@ -112,21 +110,21 @@ namespace Health.Direct.Common.Tests.Mime
         [Fact]
         public void DeserializeThrowsArgumentNullException2()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((Stream) null));
+            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((Stream)null));
             Assert.Equal("stream", ex.ParamName);
         }
 
         [Fact]
         public void DeserializeThrowsArgumentNullException3()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((string) null));
+            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((string)null));
             Assert.Equal("messageText", ex.ParamName);
         }
 
         [Fact]
         public void DeserializeThrowsArgumentNullException4()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((TextReader) null));
+            var ex = Assert.Throws<ArgumentNullException>(() => m_serializer.Deserialize<MimeEntity>((TextReader)null));
             Assert.Equal("reader", ex.ParamName);
         }
     }

--- a/csharp/unittests/common/Mime/EntityPartFacts.cs
+++ b/csharp/unittests/common/Mime/EntityPartFacts.cs
@@ -11,12 +11,10 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime
@@ -26,7 +24,7 @@ namespace Health.Direct.Common.Tests.Mime
         [Fact]
         public void CallingEntityPartyWithNullTextThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new Body((string) null));
+            Assert.Throws<ArgumentNullException>(() => new Body((string)null));
         }
 
         [Fact]

--- a/csharp/unittests/common/Mime/HeaderCollectionFacts.cs
+++ b/csharp/unittests/common/Mime/HeaderCollectionFacts.cs
@@ -11,13 +11,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime
@@ -28,7 +26,7 @@ namespace Health.Direct.Common.Tests.Mime
 
         public HeaderCollectionFacts()
         {
-            m_headers = new HeaderCollection(new[] {new Header("key", "value")});
+            m_headers = new HeaderCollection(new[] { new Header("key", "value") });
         }
 
         [Fact]
@@ -59,7 +57,7 @@ namespace Health.Direct.Common.Tests.Mime
         public void AddUpdateThrowsArgumentNullException2()
         {
             var headers = new HeaderCollection();
-            var ex = Assert.Throws<ArgumentNullException>(() => headers.AddUpdate((IEnumerable<KeyValuePair<string,string>>)null));
+            var ex = Assert.Throws<ArgumentNullException>(() => headers.AddUpdate((IEnumerable<KeyValuePair<string, string>>)null));
             Assert.Equal("headers", ex.ParamName);
         }
 
@@ -109,7 +107,7 @@ namespace Health.Direct.Common.Tests.Mime
             var a = new Header("a", "a");
             var b = new Header("b", "b");
             var aa = new Header("aa", "c");
-            Header[] headers =  new Header[] { a, b, aa };
+            Header[] headers = new Header[] { a, b, aa };
             HeaderCollection coll = new HeaderCollection();
 
             coll.Add(headers, h => h.Name.StartsWith("a"));
@@ -133,6 +131,5 @@ namespace Health.Direct.Common.Tests.Mime
             Assert.True(coll.Contains(aa));
             Assert.False(coll.Contains(b));
         }
-
     }
 }

--- a/csharp/unittests/common/Mime/HeaderFacts.cs
+++ b/csharp/unittests/common/Mime/HeaderFacts.cs
@@ -12,15 +12,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Health.Direct.Common.Mime;
 using Health.Direct.Common.Mail;
+using Health.Direct.Common.Mime;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mime
 {
@@ -59,7 +57,7 @@ namespace Health.Direct.Common.Tests.Mime
         {
             var pair = new KeyValuePair<string, string>(name, "value");
             var header = new Header(pair);
-            Assert.Equal(expected, header.IsHeaderNameOneOf(new[] {"to", "from", "cc", "subject"}));
+            Assert.Equal(expected, header.IsHeaderNameOneOf(new[] { "to", "from", "cc", "subject" }));
         }
 
         [Fact]
@@ -93,12 +91,12 @@ namespace Health.Direct.Common.Tests.Mime
         public void LineFolding(int characterCount, int expectedLines)
         {
             string source = new string('a', characterCount);
-            
+
             string foldedText = null;
-            Assert.DoesNotThrow(() => foldedText = Header.LineFoldText(source, MailStandard.MaxCharsInLine));
+            Assert.Null(Record.Exception(() => foldedText = Header.LineFoldText(source, MailStandard.MaxCharsInLine)));
             Assert.True(!string.IsNullOrEmpty(foldedText));
-            
-            string[] lines = foldedText.Split(new string[] {MailStandard.CRLF}, StringSplitOptions.None);
+
+            string[] lines = foldedText.Split(new string[] { MailStandard.CRLF }, StringSplitOptions.None);
             Assert.True(lines.Length == expectedLines);
             for (int i = 0; i < lines.Length; ++i)
             {
@@ -114,6 +112,6 @@ namespace Health.Direct.Common.Tests.Mime
                     Assert.True(line[line.Length - 1] != MimeStandard.LF);
                 }
             }
-        }        
+        }
     }
 }

--- a/csharp/unittests/common/Mime/MimeEntityCollectionFacts.cs
+++ b/csharp/unittests/common/Mime/MimeEntityCollectionFacts.cs
@@ -11,10 +11,9 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using Health.Direct.Common.Mime;
 
+using Health.Direct.Common.Mime;
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime

--- a/csharp/unittests/common/Mime/MimeEntityFacts.cs
+++ b/csharp/unittests/common/Mime/MimeEntityFacts.cs
@@ -11,15 +11,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
 
 using System.Linq;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mime
 {
@@ -49,7 +45,6 @@ namespace Health.Direct.Common.Tests.Mime
             Assert.False(e.IsMultiPart);
         }
 
-
         [Fact]
         public void BodyTextShouldBeAccessible()
         {
@@ -74,14 +69,14 @@ namespace Health.Direct.Common.Tests.Mime
             Assert.Equal("text/silly; charset=uk-monty", e.ContentType);
         }
 
-        [Fact] 
+        [Fact]
         public void MimeEntityShouldHaveHeaders()
         {
             MimeEntity e = new MimeEntity("Hello, world", "text/silly");
             e.ContentDisposition = "inline";
             e.ContentTransferEncoding = "base64";
             e.Headers.Add(new Header("foo", "bar"));
-            
+
             Assert.True(e.HasHeader("FOO"));
             Assert.Equal(4, e.Headers.Count);
         }
@@ -114,7 +109,6 @@ namespace Health.Direct.Common.Tests.Mime
                 return m_basicMultipart;
             }
         }
-
 
         [Fact]
         public void MultipartEntityShouldBeMultipart()
@@ -149,6 +143,5 @@ namespace Health.Direct.Common.Tests.Mime
             Assert.True(BasicMultipartEntity.GetParts()
                             .ElementAt(index).ContentType.Equals(content) == expected);
         }
-
     }
 }

--- a/csharp/unittests/common/Mime/MimeFieldsFacts.cs
+++ b/csharp/unittests/common/Mime/MimeFieldsFacts.cs
@@ -11,20 +11,17 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Net.Mime;
 using System.Net.Mail;
-using Health.Direct.Common.Mime;
+using System.Net.Mime;
 using Health.Direct.Common.BlueButton;
+using Health.Direct.Common.Mime;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mime
 {
@@ -34,7 +31,7 @@ namespace Health.Direct.Common.Tests.Mime
         {
             get
             {
-                yield return new object[] { 
+                yield return new object[] {
                     new ContentType {
                         MediaType = MediaTypeNames.Text.Plain,
                         Name = "FooFile.txt",
@@ -42,108 +39,108 @@ namespace Health.Direct.Common.Tests.Mime
                     },
                     3
                 };
-                
+
                 ContentType c = new ContentType("message/partial");
                 c.Name = "Bingo";
                 c.Parameters["id"] = "28a3sesd313@xyx.pqr";
                 c.Parameters["number"] = "1";
                 c.Parameters["quoted"] = "(foo<bar?q";
                 c.Parameters["total"] = "3";
-                yield return new object[] {c, 6};
+                yield return new object[] { c, 6 };
             }
         }
-        
+
         public static IEnumerable<object[]> ContentDispositions
         {
             get
             {
                 DateTime now = DateTime.Now;
-                ContentDisposition cd = new ContentDisposition {
-                        DispositionType = "attachment",
-                        FileName = "goobar.txt",
-                        CreationDate = now,
-                        ReadDate = now.AddDays(5),
-                        ModificationDate = now.AddDays(3),    
-                        Size = 123456789                    
-                    };
+                ContentDisposition cd = new ContentDisposition
+                {
+                    DispositionType = "attachment",
+                    FileName = "goobar.txt",
+                    CreationDate = now,
+                    ReadDate = now.AddDays(5),
+                    ModificationDate = now.AddDays(3),
+                    Size = 123456789
+                };
                 cd.Parameters["XYZ"] = "pqr/?.<";
                 yield return new object[]
                 {
                     cd, 7
                 };
-                
+
                 //Ensure hour of date time is in an hour that could result in a single hour digit
                 now = new DateTime(2014, 3, 20, 1, 10, 20, DateTimeKind.Local);
-                cd = new ContentDisposition {
-                        DispositionType = "attachment",
-                        FileName = "goobar.txt",
-                        CreationDate = now,
-                        ReadDate = now.AddDays(5),
-                        ModificationDate = now.AddDays(3),    
-                        Size = 123456789                    
-                    };
+                cd = new ContentDisposition
+                {
+                    DispositionType = "attachment",
+                    FileName = "goobar.txt",
+                    CreationDate = now,
+                    ReadDate = now.AddDays(5),
+                    ModificationDate = now.AddDays(3),
+                    Size = 123456789
+                };
                 cd.Parameters["XYZ"] = "pqr/?.<";
-                yield return new object[] { 
+                yield return new object[] {
                     cd, 7
                 };
             }
         }
-                
+
         [Theory]
-        [PropertyData("ContentTypes")]
+        [MemberData("ContentTypes")]
         public void TestContentType(ContentType contentType, int paramCount)
         {
             string fieldText = contentType.ToString();
-            
+
             MimeFieldParameters fieldParams = new MimeFieldParameters();
-            Assert.DoesNotThrow(() => fieldParams.Deserialize(fieldText));
+            Assert.Null(Record.Exception(() => fieldParams.Deserialize(fieldText)));
             Assert.True(fieldParams.Count == paramCount);
-            
+
             Assert.Equal(contentType.MediaType, fieldParams[0].Value);
             Assert.Equal<string>(contentType.Name, fieldParams["name"]);
-            
-            Assert.DoesNotThrow(() => Compare(fieldParams, contentType.Parameters));
-            
+
+            Assert.Null(Record.Exception(() => Compare(fieldParams, contentType.Parameters)));
+
             string fieldTextSerialized = null;
-            Assert.DoesNotThrow(() => fieldTextSerialized = fieldParams.Serialize());
-            
+            Assert.Null(Record.Exception(() => fieldTextSerialized = fieldParams.Serialize()));
+
             fieldParams.Clear();
-            Assert.DoesNotThrow(() => fieldParams.Deserialize(fieldTextSerialized));
+            Assert.Null(Record.Exception(() => fieldParams.Deserialize(fieldTextSerialized)));
             Assert.True(fieldParams.Count == paramCount);
-            
-            Assert.DoesNotThrow(() => new ContentType(fieldTextSerialized));            
+
+            Assert.Null(Record.Exception(() => new ContentType(fieldTextSerialized)));
         }
 
-        
-       
         /// <summary>
         ///
         /// </summary>
         /// <param name="disposition"></param>
         /// <param name="paramCount"></param>
         [Theory]
-        [PropertyData("ContentDispositions")]
+        [MemberData("ContentDispositions")]
         public void TestDisposition(ContentDisposition disposition, int paramCount)
         {
             string fieldText = disposition.ToString();
 
             MimeFieldParameters fieldParams = new MimeFieldParameters();
-            Assert.DoesNotThrow(() => fieldParams.Deserialize(fieldText));
+            Assert.Null(Record.Exception(() => fieldParams.Deserialize(fieldText)));
             Assert.True(fieldParams.Count == paramCount);
 
             Assert.Equal(disposition.DispositionType, fieldParams[0].Value);
             Assert.Equal(disposition.FileName, fieldParams["filename"]);
-            
-            Assert.DoesNotThrow(() => Compare(fieldParams, disposition.Parameters));
-            
+
+            Assert.Null(Record.Exception(() => Compare(fieldParams, disposition.Parameters)));
+
             string fieldTextSerialized = null;
-            Assert.DoesNotThrow(() => fieldTextSerialized = fieldParams.Serialize());
+            Assert.Null(Record.Exception(() => fieldTextSerialized = fieldParams.Serialize()));
 
             fieldParams.Clear();
-            Assert.DoesNotThrow(() => fieldParams.Deserialize(fieldTextSerialized));
+            Assert.Null(Record.Exception(() => fieldParams.Deserialize(fieldTextSerialized)));
             Assert.True(fieldParams.Count == paramCount);
-            
-            Assert.DoesNotThrow(() => new ContentDisposition(fieldTextSerialized));
+
+            Assert.Null(Record.Exception(() => new ContentDisposition(fieldTextSerialized)));
         }
 
         public static IEnumerable<KeyValuePair<string, string>> DocumentSourcesText
@@ -166,56 +163,57 @@ namespace Health.Direct.Common.Tests.Mime
                 yield return new KeyValuePair<string, MailAddress>("emailDoc3", new MailAddress("<frank.hardy@direct.healthvault.com>"));
             }
         }
-                
+
         [Fact]
         public void TestBlueBluttonSerialization()
-        {            
+        {
             RequestContext context = this.CreateContext();
-            
+
             MimeEntity entity = null;
-            Assert.DoesNotThrow(() => entity = context.ToMimeEntity());
-            
-            string entityText = null;            
-            Assert.DoesNotThrow(() => entityText = entity.ToString());
-            
+            Assert.Null(Record.Exception(() => entity = context.ToMimeEntity()));
+
+            string entityText = null;
+            Assert.Null(Record.Exception(() => entityText = entity.ToString()));
+
             MimeEntity parsedEntity = null;
-            Assert.DoesNotThrow(() => parsedEntity = MimeSerializer.Default.Deserialize<MimeEntity>(entityText));
+            Assert.Null(Record.Exception(() => parsedEntity = MimeSerializer.Default.Deserialize<MimeEntity>(entityText)));
 
             Attachment attachment = null;
-            Assert.DoesNotThrow(() => attachment = context.ToAttachment());
+            Assert.Null(Record.Exception(() => attachment = context.ToAttachment()));
             Assert.True(attachment.ContentType.MediaType == MediaTypeNames.Text.Plain);
             Assert.True(attachment.ContentDisposition.FileName == RequestContext.AttachmentName);
-            
+
             string attachmentBody = attachment.StringContent();
             Assert.True(attachmentBody.Contains(RequestContext.FieldNames.DocumentSource));
-            
+
             RequestContext contextParsed = new RequestContext(parsedEntity.Body.Text);
             this.Compare(context.GetDocumentSources(), contextParsed.GetDocumentSources());
         }
-        
-        [Fact]        
+
+        [Fact]
         public void TestBlueButtonSources()
         {
             RequestContext context = this.CreateContext();
             List<DocumentSource> ds = null;
-            
-            Assert.DoesNotThrow(() => ds = context.GetDocumentSources().ToList());
 
-            List<DocumentSource> matches = null;            
-            Assert.DoesNotThrow(() => {
+            Assert.Null(Record.Exception(() => ds = context.GetDocumentSources().ToList()));
+
+            List<DocumentSource> matches = null;
+            Assert.Null(Record.Exception(() =>
+            {
                 matches = (
                 from doc in ds
                 where doc.IsSourceForDocument("emailDoc")
                 select doc
                 ).ToList();
-            });    
+            }));
             Assert.True(matches.Count == 2);
-            
-            int matchCount = matches.Count;                    
-            Assert.DoesNotThrow(() => context.RemoveDocumentSources());
-            Assert.True(context.Count == (matchCount -2));
+
+            int matchCount = matches.Count;
+            Assert.Null(Record.Exception(() => context.RemoveDocumentSources()));
+            Assert.True(context.Count == (matchCount - 2));
         }
-        
+
         RequestContext CreateContext()
         {
             RequestContext context = new RequestContext();
@@ -223,40 +221,40 @@ namespace Health.Direct.Common.Tests.Mime
             this.AddMailSources(context);
             return context;
         }
-        
-        void AddTextSources(RequestContext context)
-        {        
-            foreach(KeyValuePair<string, string> kv in DocumentSourcesText)
-            {
-                Assert.DoesNotThrow(() => context.Add(new DocumentSource(kv.Key, kv.Value)));
-            }
-        } 
 
-        void AddMailSources(RequestContext context)
-        {    
-            foreach (KeyValuePair<string, MailAddress> kv in DocumentSourcesMailAddress)
+        void AddTextSources(RequestContext context)
+        {
+            foreach (KeyValuePair<string, string> kv in DocumentSourcesText)
             {
-                Assert.DoesNotThrow(() => context.Add(new DocumentSource(kv.Key, kv.Value)));
+                Assert.Null(Record.Exception(() => context.Add(new DocumentSource(kv.Key, kv.Value))));
             }
         }
-        
+
+        void AddMailSources(RequestContext context)
+        {
+            foreach (KeyValuePair<string, MailAddress> kv in DocumentSourcesMailAddress)
+            {
+                Assert.Null(Record.Exception(() => context.Add(new DocumentSource(kv.Key, kv.Value))));
+            }
+        }
+
         void Compare(MimeFieldParameters mfp, StringDictionary pd)
-        {   
-            foreach(string key in pd.Keys)
+        {
+            foreach (string key in pd.Keys)
             {
                 Assert.Equal(pd[key], mfp[key]);
             }
-        } 
-        
+        }
+
         void Compare(IEnumerable<DocumentSource> x, IEnumerable<DocumentSource> y)
         {
             List<DocumentSource> xl = null;
             List<DocumentSource> yl = null;
-            
-            Assert.DoesNotThrow(() => xl = x.ToList());
-            Assert.DoesNotThrow(() => yl = y.ToList());
+
+            Assert.Null(Record.Exception(() => xl = x.ToList()));
+            Assert.Null(Record.Exception(() => yl = y.ToList()));
             Assert.True(xl.Count == yl.Count);
-            
+
             for (int i = 0, count = xl.Count; i < count; ++i)
             {
                 Assert.True(xl[i].CompareTo(yl[i]) == 0);

--- a/csharp/unittests/common/Mime/MimeSerializerFacts.cs
+++ b/csharp/unittests/common/Mime/MimeSerializerFacts.cs
@@ -11,12 +11,10 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime

--- a/csharp/unittests/common/Mime/MimeWriterFacts.cs
+++ b/csharp/unittests/common/Mime/MimeWriterFacts.cs
@@ -11,13 +11,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.IO;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Mime

--- a/csharp/unittests/common/Mime/QuotedPrintableFacts.cs
+++ b/csharp/unittests/common/Mime/QuotedPrintableFacts.cs
@@ -11,17 +11,15 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
-using System.IO;
-using Health.Direct.Common;
 using Health.Direct.Common.Mime;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mime
 {
@@ -31,39 +29,39 @@ namespace Health.Direct.Common.Tests.Mime
         {
             get
             {
-                yield return new[] { 
+                yield return new[] {
                         "There is no code in this",
                         "There is no code in this"
                 };
-                yield return new[] { 
+                yield return new[] {
                         "There is only one=\r\n",
                         "There is only one"
                 };
-                yield return new[] { 
-                        "There is only one =\r\n line in this text", 
+                yield return new[] {
+                        "There is only one =\r\n line in this text",
                         "There is only one  line in this text"
                 };
-                yield return new[] { 
+                yield return new[] {
                         "This line has trailing encoded whitespace.=20=20=20",
                         "This line has trailing encoded whitespace.   ",
                 };
-                yield return new[] { 
+                yield return new[] {
                         "This line has trailing non-encoded whitespace.=20=20=20  \t\t\t  ",
                         "This line has trailing non-encoded whitespace.   ",
                 };
-                yield return new[] { 
+                yield return new[] {
                         "This line has trailing non-encoded whitespace.=\r\n  \t\t\r\n\t  ",
                         "This line has trailing non-encoded whitespace.\r\n",
                 };
-                yield return new[] { 
+                yield return new[] {
                         "This line has trailing non-encoded whitespace.=\r\n  A\t\t\t  ",
                         "This line has trailing non-encoded whitespace.  A",
                 };
-                yield return new[] { 
+                yield return new[] {
                         "This is line one=\r\n, and this is line two =\r\n and line 3.",
                         "This is line one, and this is line two  and line 3."
                 };
-                yield return new[] { 
+                yield return new[] {
                         "This example does some =\r\nof everything,\r\n=20and then=20=\r\nsome more of=0D=0Aeverything.",
                         "This example does some of everything,\r\n and then some more of\r\neverything.",
                 };
@@ -71,42 +69,42 @@ namespace Health.Direct.Common.Tests.Mime
         }
 
         [Theory]
-        [PropertyData("GoodStrings")]
+        [MemberData("GoodStrings")]
         public void TestStandard(string text, string expectedText)
         {
             QuotedPrintableDecoder decoder = new QuotedPrintableDecoder(text);
             char[] chars = null;
-            Assert.DoesNotThrow(() => chars = decoder.GetChars().ToArray()); 
+            Assert.Null(Record.Exception(() => chars = decoder.GetChars().ToArray()));
             Assert.True(chars.Length == expectedText.Length);
-            
-            string decodedString = null;    
-            Assert.DoesNotThrow(() => decodedString = new string(chars));
-            Assert.True(string.Equals(decodedString , expectedText));
+
+            string decodedString = null;
+            Assert.Null(Record.Exception(() => decodedString = new string(chars)));
+            Assert.True(string.Equals(decodedString, expectedText));
         }
-                
+
         public static IEnumerable<object[]> FileNames
         {
             get
             {
-                yield return new[] {"QuotedHtml_1.txt"};
-                yield return new[] { "QuotedHtml_2.txt"};
+                yield return new[] { "QuotedHtml_1.txt" };
+                yield return new[] { "QuotedHtml_2.txt" };
                 yield return new[] { "QuotedXml_1.txt" };
             }
         }
-        
+
         [Theory]
-        [PropertyData("FileNames")]
+        [MemberData("FileNames")]
         public void TestFiles(string fileName)
         {
             string text = LoadFile(fileName);
             QuotedPrintableDecoder decoder = new QuotedPrintableDecoder(text);
 
             char[] chars = null;
-            Assert.DoesNotThrow(() => chars = decoder.GetChars().ToArray());
+            Assert.Null(Record.Exception(() => chars = decoder.GetChars().ToArray()));
             string decodedString = null;
-            Assert.DoesNotThrow(() => decodedString = new string(chars));            
+            Assert.Null(Record.Exception(() => decodedString = new string(chars)));
         }
-        
+
         public static string LoadFile(string name)
         {
             string path = Path.Combine("Mime\\TestFiles", name);
@@ -117,54 +115,54 @@ namespace Health.Direct.Common.Tests.Mime
         {
             get
             {
-                yield return new object[] { true};  
-                yield return new object[] { false};  
+                yield return new object[] { true };
+                yield return new object[] { false };
             }
         }
-        
+
         [Theory]
-        [PropertyData("TestAllCharsParams")]
+        [MemberData("TestAllCharsParams")]
         public void TestAllChars(bool lowerCase)
         {
             // Quoted printable all possible chars
             TestString testString = this.MakeAllEncodeChars(lowerCase);
             string decoded = null;
-            Assert.DoesNotThrow(() => decoded = new QuotedPrintableDecoder(testString.Encoded).GetString());
-            
+            Assert.Null(Record.Exception(() => decoded = new QuotedPrintableDecoder(testString.Encoded).GetString()));
+
             Assert.True(testString.Expected.Length == decoded.Length);
             for (byte i = 0; i < decoded.Length; ++i)
             {
                 Assert.True(testString.Expected[i] == decoded[i]);
-            } 
+            }
         }
-        
+
         public static IEnumerable<object[]> RandomTestParams
         {
             get
             {
-                yield return new object[] {8192, 0.4, 0.5};  // String with 8K chars, 0.4 chance of encoding a char, 0.5 chance of lower case
-                yield return new object[] {65000, 0.3, 0.5};  // String with 65K chars, 20% chance of encoding a char
-                yield return new object[] {1024 * 1024, 0.2, 0.5 };  
+                yield return new object[] { 8192, 0.4, 0.5 };  // String with 8K chars, 0.4 chance of encoding a char, 0.5 chance of lower case
+                yield return new object[] { 65000, 0.3, 0.5 };  // String with 65K chars, 20% chance of encoding a char
+                yield return new object[] { 1024 * 1024, 0.2, 0.5 };
             }
         }
-                    
+
         [Theory]
-        [PropertyData("RandomTestParams")]
+        [MemberData("RandomTestParams")]
         public void TestRandom(int textLength, double encodeProbability, double lowerCaseProbability)
         {
-            TestString testString = this.MakeRandom(textLength, encodeProbability,lowerCaseProbability);            
+            TestString testString = this.MakeRandom(textLength, encodeProbability, lowerCaseProbability);
             string decodedString = null;
-            Assert.DoesNotThrow(() => decodedString = new QuotedPrintableDecoder(testString.Encoded).GetString());
+            Assert.Null(Record.Exception(() => decodedString = new QuotedPrintableDecoder(testString.Encoded).GetString()));
             Assert.True(testString.Expected.Length == decodedString.Length);
-            Assert.True(testString.Expected.Equals(decodedString));            
+            Assert.True(testString.Expected.Equals(decodedString));
         }
 
         public static IEnumerable<object[]> BadStrings
         {
             get
             {
-                yield return new[] {"Standalone = not allowed"};
-                yield return new[] {"Standalone =not allowed"};
+                yield return new[] { "Standalone = not allowed" };
+                yield return new[] { "Standalone =not allowed" };
                 yield return new[] { "Standalone ==not allowed" };
                 yield return new[] { "Bad soft linebreak=\r in line" };
                 yield return new[] { "Bad soft linebreak=\rin line" };
@@ -185,15 +183,15 @@ namespace Health.Direct.Common.Tests.Mime
                 yield return new[] { "Bad encoding line=0g" };
             }
         }
-        
+
         [Theory]
-        [PropertyData("BadStrings")]
+        [MemberData("BadStrings")]
         public void TestFailures(string badString)
         {
             string decoded = null;
             Assert.Throws<MimeException>(() => decoded = new QuotedPrintableDecoder(badString).GetString());
         }
-        
+
         TestString MakeAllEncodeChars(bool lowerCase)
         {
             StringBuilder allEncoded = new StringBuilder();
@@ -201,16 +199,16 @@ namespace Health.Direct.Common.Tests.Mime
             for (int ch = 1; ch <= byte.MaxValue; ++ch)
             {
                 allEncoded.Append(this.Encode((char)ch, lowerCase));
-                expected.Append((char) ch);
+                expected.Append((char)ch);
             }
-            
+
             return new TestString
             {
                 Encoded = allEncoded.ToString(),
                 Expected = expected.ToString()
             };
         }
-        
+
         TestString MakeRandom(int textLength, double encodeProbability, double lowerCaseProbability)
         {
             Random rand = new Random();
@@ -219,8 +217,8 @@ namespace Health.Direct.Common.Tests.Mime
             int lineLength = 0;
             for (int i = 0; i < textLength; ++i)
             {
-                char ch = (char) rand.Next(1, byte.MaxValue);
-                
+                char ch = (char)rand.Next(1, byte.MaxValue);
+
                 if (ch == MimeStandard.CR || ch == MimeStandard.LF)
                 {
                     encodedBuilder.Append(MimeStandard.CRLF);
@@ -228,8 +226,8 @@ namespace Health.Direct.Common.Tests.Mime
                     lineLength += 2;
                     continue;
                 }
-                
-                if (ch == QuotedPrintableDecoder.EncodingChar || 
+
+                if (ch == QuotedPrintableDecoder.EncodingChar ||
                     MimeStandard.IsWhitespace(ch) ||            // Always encode whitespace
                     rand.NextDouble() <= encodeProbability)
                 {
@@ -253,14 +251,14 @@ namespace Health.Direct.Common.Tests.Mime
                 }
                 expectedBuilder.Append(ch);
             }
-            
+
             return new TestString
             {
                 Encoded = encodedBuilder.ToString(),
                 Expected = expectedBuilder.ToString()
             };
         }
-                                
+
         string Encode(char ch, bool lowerCase)
         {
             if (lowerCase)
@@ -269,7 +267,7 @@ namespace Health.Direct.Common.Tests.Mime
             }
             return string.Format("={0:X2}", (byte)ch);
         }
-        
+
         internal struct TestString
         {
             internal string Encoded;

--- a/csharp/unittests/common/Mime/StringSegmentFacts.cs
+++ b/csharp/unittests/common/Mime/StringSegmentFacts.cs
@@ -11,15 +11,12 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Linq;
-
 using Health.Direct.Common.Mime;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Mime
 {
@@ -134,7 +131,7 @@ namespace Health.Direct.Common.Tests.Mime
         public void Item(string content)
         {
             var segment = new StringSegment(content);
-            for (int i=0; i<content.Length; i++)
+            for (int i = 0; i < content.Length; i++)
             {
                 Assert.Equal(content[i], segment[i]);
             }
@@ -228,7 +225,7 @@ namespace Health.Direct.Common.Tests.Mime
         public void StartsWith()
         {
             var segment = new StringSegment(TestContent);
-            for (int i=0; i<TestContent.Length; i++)
+            for (int i = 0; i < TestContent.Length; i++)
             {
                 string prefix = TestContent.Substring(0, i);
                 Assert.True(segment.StartsWith(prefix));

--- a/csharp/unittests/common/Routing/LoadBalancerFacts.cs
+++ b/csharp/unittests/common/Routing/LoadBalancerFacts.cs
@@ -11,16 +11,12 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using System;
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
 using Health.Direct.Common.Routing;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.Routing
 {
@@ -30,20 +26,20 @@ namespace Health.Direct.Common.Tests.Routing
     public class LoadBalancerFacts
     {
         string m_root;
-        
+
         public LoadBalancerFacts()
         {
             m_root = EnsureRootFolder("routerUnitTest");
         }
-        
+
         [Fact]
         public void TestNoRoute()
         {
             string receiverRoot = EnsureCleanFolder(Path.Combine(m_root, "receivers"));
-            FolderBalancer<KeyValuePair<string, string>> balancer = new FolderBalancer<KeyValuePair<string,string>>(this.TextCopy);
-            Assert.False(balancer.Process(new KeyValuePair<string,string>("foo", "Hello")));
+            FolderBalancer<KeyValuePair<string, string>> balancer = new FolderBalancer<KeyValuePair<string, string>>(this.TextCopy);
+            Assert.False(balancer.Process(new KeyValuePair<string, string>("foo", "Hello")));
         }
-                
+
         [Theory]
         [InlineData(1)]
         [InlineData(2)]
@@ -51,9 +47,9 @@ namespace Health.Direct.Common.Tests.Routing
         [InlineData(4)]
         public void TestRoundRobin(int folderCount)
         {
-            string receiverRoot = EnsureCleanFolder(Path.Combine(m_root, "receivers"));   
+            string receiverRoot = EnsureCleanFolder(Path.Combine(m_root, "receivers"));
             FolderBalancer<KeyValuePair<string, string>> balancer = this.CreateBalancer(folderCount);
-            
+
             int fileNumber = -1;
             //
             // These should all succeed
@@ -63,7 +59,7 @@ namespace Health.Direct.Common.Tests.Routing
                 ++fileNumber;
                 Process(balancer, fileNumber.ToString(), i);
             }
-            
+
             ++fileNumber;
             Process(balancer, fileNumber.ToString(), 0);
         }
@@ -76,14 +72,14 @@ namespace Health.Direct.Common.Tests.Routing
                 {
                     for (int j = 1; j <= i; ++j)
                     {
-                        yield return new object[] {i, j};
-                    }                    
+                        yield return new object[] { i, j };
+                    }
                 }
             }
         }
-        
+
         [Theory]
-        [PropertyData("FailureParams")]
+        [MemberData("FailureParams")]
         public void TestFailure(int folderCount, int failureCount)
         {
             string receiverRoot = EnsureCleanFolder(Path.Combine(m_root, "receivers"));
@@ -95,8 +91,8 @@ namespace Health.Direct.Common.Tests.Routing
             {
                 Directory.Delete(balancer.Receivers[i]);
             }
-            
-            int fileNumber = -1;            
+
+            int fileNumber = -1;
             string fileName = null;
             if (failureCount < folderCount)
             {
@@ -107,7 +103,7 @@ namespace Health.Direct.Common.Tests.Routing
                 {
                     ++fileNumber;
                     fileName = fileNumber.ToString();
-                    Assert.DoesNotThrow(() => balancer.Process(new KeyValuePair<string, string>(fileName, "Hello")));
+                    Assert.Null(Record.Exception(() => balancer.Process(new KeyValuePair<string, string>(fileName, "Hello"))));
                     Assert.True(Locate(balancer, fileName) >= 0);
                 }
             }
@@ -125,18 +121,18 @@ namespace Health.Direct.Common.Tests.Routing
                 }
             }
         }
-        
+
         FolderBalancer<KeyValuePair<string, string>> CreateBalancer(int folderCount)
         {
-            return new FolderBalancer<KeyValuePair<string, string>>(m_root, folderCount, this.TextCopy);            
+            return new FolderBalancer<KeyValuePair<string, string>>(m_root, folderCount, this.TextCopy);
         }
 
         void Process(FolderBalancer<KeyValuePair<string, string>> balancer, string fileName, int expectedIndex)
         {
-            Assert.DoesNotThrow(() => balancer.Process(new KeyValuePair<string, string>(fileName, "Hello")));
+            Assert.Null(Record.Exception(() => balancer.Process(new KeyValuePair<string, string>(fileName, "Hello"))));
             Assert.True(File.Exists(Path.Combine(balancer.Receivers[expectedIndex], fileName)));
         }
-        
+
         int Locate(FolderBalancer<KeyValuePair<string, string>> balancer, string fileName)
         {
             string[] folders = balancer.Receivers;
@@ -153,16 +149,16 @@ namespace Health.Direct.Common.Tests.Routing
                 {
                 }
             }
-            
+
             return -1;
         }
-        
+
         string EnsureRootFolder(string name)
         {
             string path = Path.Combine(Path.GetTempPath(), name);
             return EnsureCleanFolder(path);
         }
-        
+
         string EnsureCleanFolder(string path)
         {
             if (Directory.Exists(path))
@@ -171,8 +167,8 @@ namespace Health.Direct.Common.Tests.Routing
             }
             Directory.CreateDirectory(path);
             return path;
-        }        
-        
+        }
+
         bool TextCopy(KeyValuePair<string, string> file, string folderPath)
         {
             try
@@ -183,10 +179,8 @@ namespace Health.Direct.Common.Tests.Routing
             catch
             {
             }
-            
+
             return false;
         }
-        
-        
     }
 }

--- a/csharp/unittests/common/TestingBase.cs
+++ b/csharp/unittests/common/TestingBase.cs
@@ -15,9 +15,9 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+
 using System;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests
 {
@@ -119,20 +119,20 @@ namespace Health.Direct.Common.Tests
             Console.Out.WriteLine(msg);
         }
     }
-    
+
     public static class AssertEx
     {
         public static Exception Throws(Action action)
         {
             try
-            { 
+            {
                 action();
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 return ex;
             }
-            
+
             Assert.True(false, "Method did not throw exception!");
             return null;
         }
@@ -146,7 +146,7 @@ namespace Health.Direct.Common.Tests
                 {
                     action();
                 }
-                catch(T ex)
+                catch (T ex)
                 {
                     return ex;
                 }
@@ -154,10 +154,10 @@ namespace Health.Direct.Common.Tests
             catch
             {
             }
-                        
+
             Assert.True(false, string.Format("Method did not throw exception of type {0}", typeof(T)));
-            
+
             return null;
         }
-    }   
+    }
 }

--- a/csharp/unittests/common/common.tests.csproj
+++ b/csharp/unittests/common/common.tests.csproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\build\</SolutionDir>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -12,11 +16,6 @@
     <AssemblyName>Health.Direct.Common.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -33,6 +32,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,18 +70,26 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
-    <Reference Include="System.Core"/>
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit, Version=1.6.1.1521, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\external\xunit\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.extensions, Version=1.6.1.1521, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\external\xunit\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -165,8 +173,6 @@
     <Content Include="Mail\TestFiles\Wrapped_Quoted.eml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="DsnTestMessages\DSNMessage.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -194,6 +200,7 @@
     <Content Include="Mime\TestFiles\QuotedXml_1.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -212,16 +219,15 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/csharp/unittests/common/dnsResolver/BasicResolverTests.cs
+++ b/csharp/unittests/common/dnsResolver/BasicResolverTests.cs
@@ -11,16 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Health.Direct.Common.DnsResolver;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.DnsResolver
 {
@@ -79,14 +76,14 @@ namespace Health.Direct.Common.Tests.DnsResolver
         }
 
         [Theory(Skip = "Requires remote DNS call on port 53.")]
-        [PropertyData("CertDomainNames")]
+        [MemberData("CertDomainNames")]
         public void TestCert(string domain)
         {
             Resolve(DnsRequest.CreateCERT(domain));
         }
 
         [Theory(Skip = "Requires remote DNS call on port 53.")]
-        [PropertyData("CertDomainNames")]
+        [MemberData("CertDomainNames")]
         public void ResolveCert(string domain)
         {
             IEnumerable<CertRecord> certs = m_client.ResolveCERTFromNameServer(domain);

--- a/csharp/unittests/common/dnsResolver/TestSerialization.cs
+++ b/csharp/unittests/common/dnsResolver/TestSerialization.cs
@@ -11,16 +11,13 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System.Collections.Generic;
-using System.Net;
 using System.IO;
-
+using System.Net;
 using Health.Direct.Common.DnsResolver;
-
 using Xunit;
-using Xunit.Extensions;
 
 namespace Health.Direct.Common.Tests.DnsResolver
 {
@@ -32,7 +29,7 @@ namespace Health.Direct.Common.Tests.DnsResolver
             {
                 yield return new[] { "foo", "65.55.12.249" };
                 yield return new[] { "www.microsoft.com", "65.55.12.249" };
-                yield return new[] {"www.bing.com", "67.148.71.19"};
+                yield return new[] { "www.bing.com", "67.148.71.19" };
             }
         }
 
@@ -53,21 +50,21 @@ namespace Health.Direct.Common.Tests.DnsResolver
                 yield return new[] { "umesh.cer" };
             }
         }
-            
+
         [Theory]
-        [PropertyData("AddressData")]
+        [MemberData("AddressData")]
         public void TestA(string name, string ip)
         {
-            IPAddress original = IPAddress.Parse(ip);            
+            IPAddress original = IPAddress.Parse(ip);
             AddressRecord record = new AddressRecord(name, original.ToIPV4());
             Assert.True(record.IPAddress.Equals(original));
-            
-            AddressRecord parsedRecord = this.Roundtrip<AddressRecord>(record);            
+
+            AddressRecord parsedRecord = this.Roundtrip<AddressRecord>(record);
             Assert.True(parsedRecord.Equals(record));
         }
 
         [Theory]
-        [PropertyData("MxData")]
+        [MemberData("MxData")]
         public void TestMX(string name, string exchange)
         {
             MXRecord record = new MXRecord(name, exchange);
@@ -76,19 +73,19 @@ namespace Health.Direct.Common.Tests.DnsResolver
         }
 
         [Theory]
-        [PropertyData("CertData")]
+        [MemberData("CertData")]
         public void TestCert(string name)
         {
             CertRecord record = new CertRecord(this.LoadCert(name));
             CertRecord parsedRecord = this.Roundtrip<CertRecord>(record);
             Assert.True(parsedRecord.Equals(record));
         }
-        
+
         [Fact]
         public void TestValidation()
         {
             DnsRequest request = DnsRequest.CreateA("foo.com");
-            Assert.DoesNotThrow(() => request.Validate());
+            Assert.Null(Record.Exception(() => request.Validate()));
             request.Header.IsRequest = false;
             Assert.Throws<DnsProtocolException>(() => request.Validate());
         }
@@ -98,14 +95,14 @@ namespace Health.Direct.Common.Tests.DnsResolver
         {
             DnsProtocolException ex = new DnsProtocolException(DnsProtocolError.InvalidMXRecord);
             string error;
-            Assert.DoesNotThrow(() => ex.ToString());
-            Assert.DoesNotThrow(() => error = ex.Message);
+            Assert.Null(Record.Exception(() => ex.ToString()));
+            Assert.Null(Record.Exception(() => error = ex.Message));
             Assert.True(ex.ToString().Contains("MXRecord"));
             Assert.True(ex.Message.Contains("MXRecord"));
 
             ex = new DnsProtocolException(DnsProtocolError.InvalidMXRecord, IPAddress.Parse("1.2.3.4"));
-            Assert.DoesNotThrow(() => ex.ToString());
-            Assert.DoesNotThrow(() => error = ex.Message);
+            Assert.Null(Record.Exception(() => ex.ToString()));
+            Assert.Null(Record.Exception(() => error = ex.Message));
             Assert.True(ex.ToString().Contains("MXRecord"));
             Assert.True(ex.Message.Contains("MXRecord"));
             Assert.True(ex.ToString().Contains("1.2.3.4"));
@@ -119,9 +116,9 @@ namespace Health.Direct.Common.Tests.DnsResolver
             record.Serialize(buffer);
 
             DnsBufferReader reader = buffer.CreateReader();
-            return (T) DnsResourceRecord.Deserialize(ref reader);        
+            return (T)DnsResourceRecord.Deserialize(ref reader);
         }
-                        
+
         DnsX509Cert LoadCert(string name)
         {
             string path = Path.Combine(Directory.GetCurrentDirectory(), Path.Combine("DnsResolver", Path.Combine("DnsTestCerts", name)));

--- a/csharp/unittests/common/metadata/AuthorFacts.cs
+++ b/csharp/unittests/common/metadata/AuthorFacts.cs
@@ -11,20 +11,16 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System.Linq;
-
 using Health.Direct.Common.Metadata;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Metadata
 {
     public class AuthorFacts
     {
-
-
         [Fact]
         public void SimpleAuthor()
         {
@@ -38,7 +34,7 @@ namespace Health.Direct.Common.Tests.Metadata
         public void AuthorWithMI()
         {
             Author a = new Author();
-            a.Person = new Person { First="Tom", Last="Jones", MI="A" };
+            a.Person = new Person { First = "Tom", Last = "Jones", MI = "A" };
             Assert.Equal("Tom A Jones", a.Person.ToString());
             Assert.Equal("^Jones^Tom^A^^^", a.Person.ToXCN());
         }
@@ -84,7 +80,7 @@ namespace Health.Direct.Common.Tests.Metadata
         {
             Author a = new Author();
             a.Institutions.Add(new Institution("ONC-U"));
-            Assert.Contains("ONC-U", a.Institutions.Select( i => i.ToXON()));
+            Assert.Contains("ONC-U", a.Institutions.Select(i => i.ToXON()));
         }
     }
 }

--- a/csharp/unittests/common/metadata/DocumentMetadataFacts.cs
+++ b/csharp/unittests/common/metadata/DocumentMetadataFacts.cs
@@ -11,25 +11,20 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Security.Cryptography;
-
-using Xunit;
-
-using Health.Direct.Common.Metadata;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Health.Direct.Common.Metadata;
+using Xunit;
 
 namespace Health.Direct.Common.Tests.Metadata
 {
     // Many other tests in XD Consume/Generate tests
     public class DocumentMetadataFacts
     {
-
         [Fact]
         public void SetDocumentSetsHash()
         {
@@ -57,7 +52,7 @@ namespace Health.Direct.Common.Tests.Metadata
             {
                 m.SetDocument(stream);
             }
-            Assert.Equal(11, m.Size);                
+            Assert.Equal(11, m.Size);
         }
 
         [Fact]

--- a/csharp/unittests/common/metadata/HL7UtilFacts.cs
+++ b/csharp/unittests/common/metadata/HL7UtilFacts.cs
@@ -11,13 +11,11 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
 using System.Collections.Generic;
-
 using Health.Direct.Common.Metadata;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Metadata

--- a/csharp/unittests/common/metadata/PatientIDFacts.cs
+++ b/csharp/unittests/common/metadata/PatientIDFacts.cs
@@ -11,10 +11,9 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
-using Health.Direct.Common.Metadata;
 
+using Health.Direct.Common.Metadata;
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Metadata

--- a/csharp/unittests/common/metadata/PersonFacts.cs
+++ b/csharp/unittests/common/metadata/PersonFacts.cs
@@ -11,19 +11,16 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-
 using Health.Direct.Common.Metadata;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Metadata
 {
     public class PersonFacts
     {
-
         [Fact]
         public void EmptyPerson()
         {
@@ -77,7 +74,7 @@ namespace Health.Direct.Common.Tests.Metadata
         [Fact]
         public void ToSourcePatientInfoResturnsCorrectAddressValue()
         {
-            Person p = new Person { First = "John", Last = "Jacob", Address = new PostalAddress { City = "Wiesbaden", State = "Hesse", Street = "Meadow Bath Ave", Zip="00000"} };
+            Person p = new Person { First = "John", Last = "Jacob", Address = new PostalAddress { City = "Wiesbaden", State = "Hesse", Street = "Meadow Bath Ave", Zip = "00000" } };
             Assert.Contains("PID-11|" + p.Address.Value.ToHL7Ad(), p.ToSourcePatientInfoValues(null));
         }
     }

--- a/csharp/unittests/common/metadata/RecipientFacts.cs
+++ b/csharp/unittests/common/metadata/RecipientFacts.cs
@@ -11,19 +11,16 @@ Redistributions of source code must retain the above copyright notice, this list
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
 */
+
 using System;
-
 using Health.Direct.Common.Metadata;
-
 using Xunit;
 
 namespace Health.Direct.Common.Tests.Metadata
 {
     public class RecipientFacts
     {
-
         [Fact]
         public static void FromXonXcnWorksForSimpleCase()
         {
@@ -34,6 +31,7 @@ namespace Health.Direct.Common.Tests.Metadata
             Assert.Equal(p, r.Person);
             Assert.Equal(i, r.Institution);
         }
+
         [Fact]
         public static void FromXonXcnMissingInstition()
         {
@@ -43,6 +41,7 @@ namespace Health.Direct.Common.Tests.Metadata
             Assert.Equal(p, r.Person);
             Assert.Null(r.Institution);
         }
+
         [Fact]
         public static void FromXonXcnMissingPerson()
         {
@@ -52,6 +51,7 @@ namespace Health.Direct.Common.Tests.Metadata
             Assert.Null(r.Person);
             Assert.Equal(i, r.Institution);
         }
+
         [Fact]
         public static void FromXonXcnMissingPersonAlternateFormat()
         {

--- a/csharp/unittests/common/packages.config
+++ b/csharp/unittests/common/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
xUnit 2.x has some changes compared to version 1.x that was used before. The recommended migration process is documented here: http://xunit.github.io/docs/test-migration.html

The changes were small, but many lines were affected. In addition, Visual Studio normalized using blocks and white space. I did manually inspected all the changes and they appear correct.

All the unit tests (except those marked as Skip explicitly) are passing using Test Explorer in both Visual Studio 2013 and 2015.