### PR TITLE
include URL in exception message when failing to download certificate from AIA extension

### DIFF
--- a/java/agent/src/main/java/org/nhindirect/stagent/trust/TrustChainValidator.java
+++ b/java/agent/src/main/java/org/nhindirect/stagent/trust/TrustChainValidator.java
@@ -474,7 +474,7 @@ public class TrustChainValidator
 		}
 		catch (Exception e)
 		{
-			throw new NHINDException("Failed to download certificates from AIA extension.", e);
+			throw new NHINDException("Failed to download certificates from AIA extension (URL: " + url + ")", e);
 		}
 		finally
 		{


### PR DESCRIPTION
Include URL in exception message when failing to download certificate from AIA extension. This can be helpful for identifying and troubleshooting URLs that are not working (eg. request time outs with "SocketTimeoutException: Read timed out").

Example stacktrace before change:
```
2017-02-22 15:08:37.978  WARN 11566 --- [SimpleAsyncTaskExecutor-5] o.n.stagent.trust.TrustChainValidator    : Intermediate cert cannot be resolved from AIA extension.
org.nhindirect.stagent.NHINDException: Failed to download certificates from AIA extension.
	at org.nhindirect.stagent.trust.TrustChainValidator.downloadCertsFromAIA(TrustChainValidator.java:477)
	at org.nhindirect.stagent.trust.TrustChainValidator.getIntermediateCertsByAIA(TrustChainValidator.java:378)
	at org.nhindirect.stagent.trust.TrustChainValidator.resolveIssuers(TrustChainValidator.java:278)
	at org.nhindirect.stagent.trust.TrustChainValidator.resolveIntermediateIssuers(TrustChainValidator.java:218)
	at org.nhindirect.stagent.trust.TrustChainValidator.resolveIntermediateIssuers(TrustChainValidator.java:203)
	at org.nhindirect.stagent.trust.TrustChainValidator.isTrusted(TrustChainValidator.java:153)
	at org.nhindirect.stagent.trust.TrustModel.findTrustedCerts(TrustModel.java:255)
	at org.nhindirect.stagent.trust.TrustModel.enforce(TrustModel.java:236)
	at org.nhindirect.stagent.DefaultNHINDAgent.processMessage(DefaultNHINDAgent.java:1306)
	at org.nhindirect.stagent.DefaultNHINDAgent.processOutgoing(DefaultNHINDAgent.java:1250)
	at org.nhindirect.stagent.DefaultNHINDAgent.processOutgoing(DefaultNHINDAgent.java:1216)
	at org.nhindirect.gateway.smtp.DefaultSmtpAgent.processEnvelope(DefaultSmtpAgent.java:332)
	at org.nhindirect.gateway.smtp.DefaultSmtpAgent.processMessage(DefaultSmtpAgent.java:202)
	... more
Caused by: java.net.SocketTimeoutException: Read timed out
	at java.net.SocketInputStream.socketRead0(Native Method)
	at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
	at java.net.SocketInputStream.read(SocketInputStream.java:170)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	at sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:704)
	at sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:647)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1536)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1441)
	at org.nhindirect.stagent.trust.TrustChainValidator.downloadCertsFromAIA(TrustChainValidator.java:470)
	... 48 common frames omitted
```