### PR TITLE
Implemented certificate builders using Bouncy Castle

### DIFF
--- a/csharp/authors.txt
+++ b/csharp/authors.txt
@@ -1,8 +1,9 @@
-Umesh Madan	umeshma@microsoft.com
-Sean Nolan	seannol@microsoft.com
-John Theisen    jtheisen@kryptiq.com
-Arien Malec	arien.malec@nhindirect.org
-Chris Lomonico  chris.lomonico@surescripts.com
-Claudio Sanchez claudio.sanchez@feisystems.com
-Vassil Peytchev	vassil@epic.com
-Ron Cordell	ron.cordell@relayhealth.com
+Umesh Madan		umeshma@microsoft.com
+Sean Nolan		seannol@microsoft.com
+John Theisen    	jtheisen@kryptiq.com
+Arien Malec		arien.malec@nhindirect.org
+Chris Lomonico  	chris.lomonico@surescripts.com
+Claudio Sanchez 	claudio.sanchez@feisystems.com
+Vassil Peytchev		vassil@epic.com
+Ron Cordell		ron.cordell@relayhealth.com
+Dávid Koronthály	koronthaly@hotmail.com

--- a/csharp/common/Certificates/AbstractBuilder.cs
+++ b/csharp/common/Certificates/AbstractBuilder.cs
@@ -1,0 +1,123 @@
+﻿/* 
+ Copyright (c) 2017, Direct Project
+ All rights reserved.
+
+ Authors:
+    Dávid Koronthály    koronthaly@hotmail.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509.Extension;
+using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
+
+namespace Health.Direct.Common.Certificates
+{
+    /// <summary>
+    /// Abstract X509 certificate builder, using Bouncy Castle library. Inspired by
+    /// http://blog.differentpla.net/blog/2013/03/18/using-bouncy-castle-from-net
+    /// </summary>
+    public abstract class AbstractBuilder
+    {
+        /// <summary>
+        /// Use CryptoApi random number generator. Initialization is costly, so share it with all builders.
+        /// </summary>
+        protected static readonly SecureRandom SecureRandom = new SecureRandom(new CryptoApiRandomGenerator());
+
+        /// <summary>
+        /// Name of the signature algorithm (see RFC 5280 section 4.1.1.2); defaults to "SHA256withRSA".
+        /// </summary>
+        public string SignatureAlgorithmName { get; set; } = "SHA256withRSA";
+
+        /// <summary>
+        /// Certificate authority, used by the builder to generate a new certificate.
+        /// Can be null if there is no issuer (e.g. when generating a self-signed certificate).
+        /// </summary>
+        public X509Certificate Issuer { get; }
+
+        /// <summary>
+        /// Issuer's key pair. Can be null if there is no issuer.
+        /// </summary>
+        public virtual AsymmetricCipherKeyPair IssuerKeyPair { get; }
+
+        /// <summary>
+        /// Issuer's serial number. Can be null if there is no issuer.
+        /// </summary>
+        public virtual BigInteger IssuerSerialNumber => Issuer?.SerialNumber;
+
+        /// <summary>
+        /// Issuer's distinguished name. See RFC 5280 section 4.1.2.4. Issuer.
+        /// Can be null if there is no issuer.
+        /// </summary>
+        public virtual X509Name IssuerDN => Issuer?.SubjectDN;
+
+        /// <summary>
+        /// Url to retrieve public key of the issuer (using access method id-ad-caIssuers). 
+        /// See RFC 5280 section 4.2.2.1. Authority Information Access
+        /// </summary>
+        public Uri AuthorityInformationAccessUri { get; set; }
+
+        /// <summary>
+        /// Create a new builder.
+        /// </summary>
+        /// <param name="issuer">Certification authority, used to issue a new certificate. Null is allowed.</param>
+        protected AbstractBuilder(X509Certificate2 issuer)
+        {
+            // Self-signed certificate does not have a separate issuer.
+            if (issuer == null)
+            {
+                return;
+            }
+
+            // Issuer must be a valid certificate authority.
+            if (!issuer.IsCertificateAuthority() || !issuer.HasValidDateRange() || !issuer.HasPrivateKey)
+            {
+                throw new ArgumentException("Not a valid certificate authority.", nameof(issuer));
+            }
+
+            // Convert to Bouncy Castle representation;
+            Issuer = DotNetUtilities.FromX509Certificate(issuer);
+            IssuerKeyPair = DotNetUtilities.GetKeyPair(issuer.PrivateKey);
+        }
+
+        /// <summary>
+        /// Encode AuthorityInformationAccessUri to a form required by the extension.
+        /// </summary>
+        /// <returns>DER encoded sequence or null.</returns>
+        protected DerSequence GetAuthorityInfoAccessEncoded()
+        {
+            if (AuthorityInformationAccessUri == null || !AuthorityInformationAccessUri.IsAbsoluteUri)
+            {
+                return null;
+            }
+
+            var location = new GeneralName(GeneralName.UniformResourceIdentifier, new DerIA5String(AuthorityInformationAccessUri.AbsoluteUri));
+            var issuers = new AccessDescription(AccessDescription.IdADCAIssuers, location);
+            return new DerSequence(new Asn1EncodableVector(issuers));
+        }
+
+        /// <summary>
+        /// Extract issuer alternative name is available.
+        /// </summary>
+        /// <returns>Issuer alternative name or null.</returns>
+        protected GeneralNames GetIssuerAlternativeName()
+        {
+            Asn1OctetString extensionValue = Issuer?.GetExtensionValue(new DerObjectIdentifier(X509Extensions.SubjectAlternativeName.Id));
+            return extensionValue == null ? null : GeneralNames.GetInstance(X509ExtensionUtilities.FromExtensionValue(extensionValue));
+        }
+    }
+}

--- a/csharp/common/Certificates/CertificateBuilder.cs
+++ b/csharp/common/Certificates/CertificateBuilder.cs
@@ -1,0 +1,388 @@
+﻿/* 
+ Copyright (c) 2017, Direct Project
+ All rights reserved.
+
+ Authors:
+    Dávid Koronthály    koronthaly@hotmail.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Health.Direct.Common.Extensions;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+
+namespace Health.Direct.Common.Certificates
+{
+    /// <summary>
+    /// Build X509 certificate that satisfies requirements of Direct Project.
+    /// See http://blog.differentpla.net/blog/2013/03/18/using-bouncy-castle-from-net
+    /// </summary>
+    public class CertificateBuilder : AbstractBuilder
+    {
+        public const int DefaultCertificateAuthorityKeyStrength = 4096;
+        public const int DefaultCertificateKeyStrength = 2048;
+        public const int DefaultValidityPeriodInMonths = 18;
+
+        // Implemented using backing field to support delayed initialization.
+        private AsymmetricCipherKeyPair _subjectKeyPair;
+
+        /// <summary>
+        /// Returns true if the builder is initialized to create a certificate authority.
+        /// </summary>
+        public bool IsCertificateAuthority
+        {
+            get { return BasicConstraints.IsCA(); }
+        }
+
+        /// <summary>
+        /// Returns true is the builder is initialized to create a self-signed certificate.
+        /// </summary>
+        public bool IsSelfSigned
+        {
+            get { return Issuer == null; }
+        }
+
+        /// <summary>
+        /// Issuer's serial number. For self-signed certificates,
+        /// it is identical to the value of the SerialNumber property.
+        /// </summary>
+        public override BigInteger IssuerSerialNumber
+        {
+            get { return IsSelfSigned ? SerialNumber : base.IssuerSerialNumber; }
+        }
+
+        /// <summary>
+        /// Issuer's distinguished name. For self-signed certificates,
+        /// it is identical to the value of the SubjectDN property.
+        /// </summary>
+        public override X509Name IssuerDN
+        {
+            get { return IsSelfSigned ? SubjectDN : base.IssuerDN; }
+        }
+
+        /// <summary>
+        /// Issuer's serial number. For self-signed certificates,
+        /// it is identical to the value of the SubjectKeyPair property.
+        /// </summary>
+        public override AsymmetricCipherKeyPair IssuerKeyPair
+        {
+            get { return IsSelfSigned ? SubjectKeyPair : base.IssuerKeyPair; }
+        }
+
+        /// <summary>
+        /// Basic Constraints, as defined by RFC 5280 section 4.2.1.9.
+        /// </summary>
+        public BasicConstraints BasicConstraints { get; }
+
+        /// <summary>
+        /// Size of the public key in bits. Defaults to 4096 for
+        /// certificate authorities and 2048 for end entities.
+        /// </summary>
+        public int KeyStrength { get; set; }
+
+        /// <summary>
+        /// Serial Number, as defined by RFC 5280 section 4.1.2.2.
+        /// </summary>
+        public BigInteger SerialNumber { get; set; }
+
+        /// <summary>
+        /// Not Before, as defined by RFC 5280 section 4.1.2.5.
+        /// </summary>
+        public DateTime NotBefore { get; set; }
+
+        /// <summary>
+        /// Not After, as defined by RFC 5280 section 4.1.2.5.
+        /// </summary>
+        public DateTime NotAfter { get; set; }
+
+        /// <summary>
+        /// Key Usage, as defined by RFC 5280 section 4.2.1.3.
+        /// </summary>
+        public X509KeyUsageFlags KeyUsage { get; set; }
+
+        /// <summary>
+        /// Certificate Policies, as defined by RFC 5280 section 4.2.1.4.
+        /// </summary>
+        public IList<string> Policies { get; }
+
+        /// <summary>
+        /// CRL Distribution Points, as defined by RFC 5280 section 4.2.1.13.
+        /// Only a single HTTP URL is supported.
+        /// </summary>
+        public Uri CrlDistributionPointUri { get; set; }
+
+        /// <summary>
+        /// Subject Alternative Name, as defined by RFC 5280 section 4.2.1.6.
+        /// </summary>
+        public GeneralNames SubjectAlternativeName { get; set; }
+
+        /// <summary>
+        /// Subject's distinguished name. See RFC 5280 section 4.1.2.6. Subject
+        /// </summary>
+        public X509Name SubjectDN { get; set; }
+
+        /// <summary>
+        /// Key pair of the new certificate. Created on demand, using KeyStrength bits.
+        /// </summary>
+        public AsymmetricCipherKeyPair SubjectKeyPair
+        {
+            get
+            {
+                if (_subjectKeyPair == null)
+                {
+                    var keyPairGenerator = new RsaKeyPairGenerator();
+                    keyPairGenerator.Init(new KeyGenerationParameters(SecureRandom, KeyStrength));
+                    _subjectKeyPair = keyPairGenerator.GenerateKeyPair();
+                }
+
+                return _subjectKeyPair;
+            }
+        }
+
+        private CertificateBuilder(X509Certificate2 issuer, bool certificateAuthority, int pathLenConstraint = 0)
+            : base(issuer)
+        {
+            // Initialize key strength
+            KeyStrength = certificateAuthority ? DefaultCertificateAuthorityKeyStrength : DefaultCertificateKeyStrength;
+
+            // Initialize serial number; can be changed.
+            SerialNumber = BigInteger.ProbablePrime(120, SecureRandom);
+
+            // Decide what kind of certificate will be issued.
+            BasicConstraints = certificateAuthority
+                ? new BasicConstraints(pathLenConstraint)
+                : new BasicConstraints(false);
+
+            // Validity period.
+            NotBefore = DateTime.UtcNow;
+            NotAfter = NotBefore.AddMonths(DefaultValidityPeriodInMonths);
+
+            // Certificate policies; see DirectTrustCertificatePolicies
+            Policies = new List<string>();
+        }
+
+        /// <summary>
+        /// Create a new CertificateBuilder, initialized to generate a self-signed certification authority.
+        /// </summary>
+        /// <param name="pathLenConstraint">
+        /// Limits the number of intermediate certificates that may follow this certificate in a valid certification path.
+        /// </param>
+        public CertificateBuilder(int pathLenConstraint)
+            : this(null, true, pathLenConstraint)
+        {
+            // Certificate authority is used to issue other certificates and CRL.
+            KeyUsage = X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign;
+        }
+
+        /// <summary>
+        /// Create a new CertificateBuilder, initialized to generate an intermediate certification authority, signed by the issuer.
+        /// </summary>
+        /// <param name="issuer">Certificate authority used to issue the certificate.</param>
+        /// <param name="pathLenConstraint">
+        /// Limits the number of intermediate certificates that may follow this certificate in a valid certification path.
+        /// </param>
+        public CertificateBuilder(X509Certificate2 issuer, int pathLenConstraint)
+            : this(issuer, true, pathLenConstraint)
+        {
+            if (issuer == null)
+            {
+                throw new ArgumentNullException(nameof(issuer));
+            }
+
+            // Certificate authority is used to issue other certificates and CRL.
+            KeyUsage = X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign;
+        }
+
+        /// <summary>
+        /// Create a new CertificateBuilder, initialized to generate end entity certificate, signed by the issuer.
+        /// </summary>
+        /// <param name="issuer">Certificate authority used to issue the certificate.</param>
+        public CertificateBuilder(X509Certificate2 issuer)
+            : this(issuer, false)
+        {
+            if (issuer == null)
+            {
+                throw new ArgumentNullException(nameof(issuer));
+            }
+
+            // Direct end entity certificates are used to sign and encrypt email.
+            KeyUsage = X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment;
+        }
+
+        /// <summary>
+        /// Initialize the SubjectAlternativeName to a domain.
+        /// </summary>
+        /// <param name="domain">Domain (host) name. Not a full URL.</param>
+        public void SetSubjectAlternativeNameToDomain(string domain)
+        {
+            if (domain.IsNullOrWhiteSpace())
+            {
+                throw new ArgumentNullException(nameof(domain));
+            }
+
+            if (SubjectAlternativeName != null)
+            {
+                throw new InvalidOperationException("SubjectAlternativeName was already set.");
+            }
+
+            SubjectAlternativeName = new GeneralNames(new GeneralName(GeneralName.DnsName, new DerIA5String(domain)));
+        }
+
+        /// <summary>
+        /// Initialize the SubjectAlternativeName to an email.
+        /// </summary>
+        /// <param name="emailAddress">Email address.</param>
+        public void SetSubjectAlternativeNameToEmail(string emailAddress)
+        {
+            if (emailAddress.IsNullOrWhiteSpace())
+            {
+                throw new ArgumentNullException(nameof(emailAddress));
+            }
+
+            if (SubjectAlternativeName != null)
+            {
+                throw new InvalidOperationException("SubjectAlternativeName was already set.");
+            }
+
+            SubjectAlternativeName = new GeneralNames(new GeneralName(GeneralName.Rfc822Name, new DerIA5String(emailAddress)));
+        }
+
+        /// <summary>
+        /// Generate and return a new X509 certificate.
+        /// </summary>
+        /// <returns></returns>
+        public X509Certificate2 Generate()
+        {
+            var generator = new X509V3CertificateGenerator();
+
+            // RFC 5280 section 4.1.2.2. Serial Number
+            generator.SetSerialNumber(SerialNumber);
+
+            // RFC 5280 section 4.1.2.4. Issuer
+            generator.SetIssuerDN(IssuerDN);
+
+            // RFC 5280 section 4.1.2.5. Validity
+            if (!IsSelfSigned && NotBefore < Issuer.NotBefore)
+            {
+                NotBefore = Issuer.NotBefore;
+            }
+
+            if (!IsSelfSigned && Issuer.NotAfter < NotAfter)
+            {
+                NotAfter = Issuer.NotAfter;
+            }
+
+            generator.SetNotBefore(NotBefore);
+            generator.SetNotAfter(NotAfter);
+
+            // RFC 5280 section 4.1.2.6. Subject; also see Direct Project 1.2 section 4.1.1.2.
+            generator.SetSubjectDN(SubjectDN);
+
+            // RFC 5280 section 4.1.2.7. Subject Public Key Info
+            generator.SetPublicKey(SubjectKeyPair.Public);
+
+            // RFC 5280 section 4.2.1.1. Authority Key Identifier
+            if (IsSelfSigned)
+            {
+                var authorityKeyIdentifier = new AuthorityKeyIdentifier(
+                    SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(SubjectKeyPair.Public),
+                    new GeneralNames(new GeneralName(SubjectDN)),
+                    SerialNumber);
+                generator.AddExtension(X509Extensions.AuthorityKeyIdentifier, false, authorityKeyIdentifier);
+            }
+            else
+            {
+                generator.AddExtension(X509Extensions.AuthorityKeyIdentifier, false, new AuthorityKeyIdentifierStructure(Issuer));
+            }
+
+            // RFC 5280 section 4.2.1.2. Subject Key Identifier
+            var subjectKeyIdentifier = new SubjectKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(SubjectKeyPair.Public));
+            generator.AddExtension(X509Extensions.SubjectKeyIdentifier.Id, false, subjectKeyIdentifier);
+
+            // RFC 5280 section 4.2.1.3. Key Usage
+            generator.AddExtension(X509Extensions.KeyUsage, false, new KeyUsage((int)KeyUsage));
+
+            // RFC 5280 section 4.2.1.4. Certificate Policies
+            if (Policies.Any())
+            {
+                var policies = Policies.Select(x => new PolicyInformation(new DerObjectIdentifier(x))).ToArray();
+                generator.AddExtension(X509Extensions.CertificatePolicies, false, new CertificatePolicies(policies));
+            }
+
+            // RFC 5280 section 4.2.1.6. Subject Alternative Name; also see Direct Project 1.2 section 4.1.1.1.
+            generator.AddExtension(X509Extensions.SubjectAlternativeName, false, SubjectAlternativeName);
+
+            // RFC 5280 section 4.2.1.9. Basic Constraints
+            generator.AddExtension(X509Extensions.BasicConstraints, true, BasicConstraints);
+
+            // RFC 5280 section 4.2.1.12. Extended Key Usage
+            generator.AddExtension(X509Extensions.ExtendedKeyUsage, false, new ExtendedKeyUsage(KeyPurposeID.IdKPEmailProtection));
+
+            // RFC 5280 section 4.2.1.13. CRL Distribution Points
+            var crlDistPoint = GetCrlDistributionPoints();
+            if (crlDistPoint != null)
+            {
+                generator.AddExtension(X509Extensions.CrlDistributionPoints, false, crlDistPoint);
+            }
+
+            // RFC 5280 section 4.2.2.1. Authority Information Access
+            var authorityInfoAccess = GetAuthorityInfoAccessEncoded();
+            if (authorityInfoAccess != null)
+            {
+                generator.AddExtension(X509Extensions.AuthorityInfoAccess, false, authorityInfoAccess);
+            }
+
+            // Generate a new certificate.
+            var certificate = generator.Generate(new Asn1SignatureFactory(SignatureAlgorithmName, (IssuerKeyPair ?? SubjectKeyPair).Private, SecureRandom));
+
+            // Create a PKCS12 store (a.PFX file) in memory, and add the public and private key to that.
+            var store = new Pkcs12Store();
+            var certificateEntry = new X509CertificateEntry(certificate);
+
+            string friendlyName = certificate.SubjectDN.ToString();
+            store.SetCertificateEntry(friendlyName, certificateEntry);
+            store.SetKeyEntry(friendlyName, new AsymmetricKeyEntry(SubjectKeyPair.Private), new[] { certificateEntry });
+
+            using (var stream = new MemoryStream())
+            {
+                // The password is required by the API, but will not be used beyond this scope.
+                const string password = "password";
+                store.Save(stream, password.ToCharArray(), SecureRandom);
+                return new X509Certificate2(
+                    stream.ToArray(),
+                    password,
+                    X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            }
+        }
+
+        private CrlDistPoint GetCrlDistributionPoints()
+        {
+            if (CrlDistributionPointUri == null || !CrlDistributionPointUri.IsAbsoluteUri)
+            {
+                return null;
+            }
+
+            var generalName = new GeneralName(GeneralName.UniformResourceIdentifier, new DerIA5String(CrlDistributionPointUri.AbsoluteUri));
+            return new CrlDistPoint(new[] { new DistributionPoint(new DistributionPointName(new GeneralNames(generalName)), null, null) });
+        }
+    }
+}

--- a/csharp/common/Certificates/CertificateRevocationListBuilder.cs
+++ b/csharp/common/Certificates/CertificateRevocationListBuilder.cs
@@ -1,0 +1,154 @@
+﻿/* 
+ Copyright (c) 2017, Direct Project
+ All rights reserved.
+
+ Authors:
+    Dávid Koronthály    koronthaly@hotmail.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+
+namespace Health.Direct.Common.Certificates
+{
+    /// <summary>
+    /// Certificate revocation list builder, using Bouncy Castle.
+    /// </summary>
+    public class CertificateRevocationListBuilder : AbstractBuilder
+    {
+        /// <summary>
+        /// CRL Number, as defined by RFC 5280 section 5.2.3.
+        /// </summary>
+        public BigInteger CrlNumber { get; }
+
+        /// <summary>
+        /// This Update, as defined by RFC 5280 section 5.1.2.4.
+        /// </summary>
+        public DateTime ThisUpdate { get; set; }
+
+        /// <summary>
+        /// Next Update, as defined by RFC 5280 section 5.1.2.5.
+        /// </summary>
+        public DateTime NextUpdate { get; set; }
+
+        /// <summary>
+        /// The list of revoked certificates (serial number + revocation date),
+        /// as defined by RFC 5280 section 5.1.2.6.
+        /// </summary>
+        public IList<Tuple<BigInteger, DateTime>> RevokedCertificates { get; }
+
+        /// <summary>
+        /// Create a new CertificateRevocationListBuilder.
+        /// </summary>
+        /// <param name="issuer">Certificate authority used to issue the CRL.</param>
+        /// <param name="crlNumber">Unique CRL number.</param>
+        public CertificateRevocationListBuilder(X509Certificate2 issuer, ulong crlNumber)
+            : base(issuer)
+        {
+            // Base class does the validation when issuer is not null.
+            if (issuer == null)
+            {
+                throw new ArgumentNullException(nameof(issuer));
+            }
+
+            // Bouncy Castle cannot construct BigInteger from a number.
+            CrlNumber = new BigInteger(crlNumber.ToString(CultureInfo.InvariantCulture));
+
+            // Per RFC 5280 the date should be in UTC.
+            ThisUpdate = DateTime.UtcNow;
+
+            // Per DirectTrust Community X.509 Certificate Policy
+            // a new CRL must be generated at least every 30 days.
+            NextUpdate = ThisUpdate.AddDays(30);
+
+            // List of revoked certificates.
+            RevokedCertificates = new List<Tuple<BigInteger, DateTime>>();
+        }
+
+        /// <summary>
+        /// Add certificate to the list of revoked certificates.
+        /// </summary>
+        /// <param name="serialNumber">Serial number of the revoked certificate.</param>
+        /// <param name="revocationDate">Date and time when the certificate was revoked.</param>
+        public void AddRevokedCertificate(BigInteger serialNumber, DateTime? revocationDate = null)
+        {
+            RevokedCertificates.Add(new Tuple<BigInteger, DateTime>(serialNumber, revocationDate ?? DateTime.Now));
+        }
+
+        /// <summary>
+        /// Add certificate to the list of revoked certificates.
+        /// </summary>
+        /// <param name="certificate">Revoked certificate.</param>
+        /// <param name="revocationDate">Date and time when the certificate was revoked.</param>
+        public void AddRevokedCertificate(X509Certificate2 certificate, DateTime? revocationDate = null)
+        {
+            AddRevokedCertificate(new BigInteger(certificate.SerialNumber, 16), revocationDate);
+        }
+
+        /// <summary>
+        /// Generate and return a new certificate revocation list.
+        /// </summary>
+        /// <returns>Certificate revocation list.</returns>
+        public X509Crl Generate()
+        {
+            var generator = new X509V2CrlGenerator();
+
+            // RFC 5280 section 5.1.2.3. Issuer Name
+            generator.SetIssuerDN(IssuerDN);
+
+            // RFC 5280 section 5.1.2.4. This Update
+            generator.SetThisUpdate(ThisUpdate);
+
+            // RFC 5280 section 5.1.2.5. Next Update
+            generator.SetNextUpdate(NextUpdate);
+
+            // RFC 5280 section 5.1.2.6. Revoked Certificates
+            foreach (var revokedCertificate in RevokedCertificates)
+            {
+                var serialNumber = revokedCertificate.Item1;
+                var revocationDate = revokedCertificate.Item2;
+                var reason = CrlReason.PrivilegeWithdrawn;
+
+                generator.AddCrlEntry(serialNumber, revocationDate, reason);
+            }
+
+            // RFC 5280 section 5.2.1. Authority Key Identifier
+            generator.AddExtension(X509Extensions.AuthorityKeyIdentifier, false, new AuthorityKeyIdentifierStructure(Issuer));
+
+            // RFC 5280 section 5.2.2. Issuer Alternative Name
+            var issuerAlternativeName = GetIssuerAlternativeName();
+            if (issuerAlternativeName != null)
+            {
+                generator.AddExtension(X509Extensions.IssuerAlternativeName, false, issuerAlternativeName);
+            }
+
+            // RFC 5280 section 5.2.3. CRL Number
+            generator.AddExtension(X509Extensions.CrlNumber, false, new CrlNumber(CrlNumber));
+
+            // RFC 5280 section 5.2.7. Authority Information Access
+            var authorityInfoAccess = GetAuthorityInfoAccessEncoded();
+            if (authorityInfoAccess != null)
+            {
+                generator.AddExtension(X509Extensions.AuthorityInfoAccess, false, authorityInfoAccess);
+            }
+
+            // Generate and return.
+            return generator.Generate(new Asn1SignatureFactory(SignatureAlgorithmName, IssuerKeyPair.Private, SecureRandom));
+        }
+    }
+}

--- a/csharp/common/Certificates/DirectTrustCertificatePolicies.cs
+++ b/csharp/common/Certificates/DirectTrustCertificatePolicies.cs
@@ -1,0 +1,83 @@
+﻿/* 
+ Copyright (c) 2017, Direct Project
+ All rights reserved.
+
+ Authors:
+    Dávid Koronthály    koronthaly@hotmail.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+namespace Health.Direct.Common.Certificates
+{
+    /// <summary>
+    /// Certificate policy OIDs, as defined by DirectTrust Community X.509 Certificate Policy version 1.2:
+    /// http://wiki.directproject.org/file/view/DirectTrust+CP+V1-1.2.pdf/409137794/DirectTrust%20CP%20V1-1.2.pdf
+    /// </summary>
+    public static class DirectTrustCertificatePolicies
+    {
+        /// <summary>
+        /// DirectTrust Community X.509 Certificate Policy version 1.2
+        /// See DirectTrust CP section 1.2 Document Name and Identification.
+        /// </summary>
+        public const string DTorgCPVersions = "1.3.6.1.4.1.41179.0.1";
+
+        /// <summary>
+        /// Levels of assurance: applicant's control over an email address.
+        /// Equivalent to NIST 800-63-1 Level 1 or Kantara Level 1 or FBCA Rudimentary
+        /// See DirectTrust CP section 3.2.3.1 Authentication of Human Subscribers.
+        /// </summary>
+        public const string DTorgLoA1 = "1.3.6.1.4.1.41179.1.1";
+
+        /// <summary>
+        /// Levels of assurance: applicant supplies his or her full legal name, an address of record, and date of birth.
+        /// Equivalent to NIST 800-63-1 Level 2 or Kantara Level 2 or FBCA Basic.
+        /// See DirectTrust CP section 3.2.3.1 Authentication of Human Subscribers.
+        /// </summary>
+        public const string DTorgLoA2 = "1.3.6.1.4.1.41179.1.2";
+
+        /// <summary>
+        /// Levels of assurance: applicant supplies his or her full legal name, an address of record, and date of birth.
+        /// Equivalent to NIST 800-63-1 Level 3 or Kantara Level 3 or FBCA Basic or Medium.
+        /// See DirectTrust CP section 3.2.3.1 Authentication of Human Subscribers.
+        /// </summary>
+        public const string DTorgLoA3 = "1.3.6.1.4.1.41179.1.3";
+
+        /// <summary>
+        /// Levels of assurance: applicant supplies his or her full legal name, an address of record, and date of birth.
+        /// Equivalent to NIST 800-63-1 Level 4 or Kantara Level 4 or FBCA Medium.
+        /// See DirectTrust CP section 3.2.3.1 Authentication of Human Subscribers.
+        /// </summary>
+        public const string DTorgLoA4 = "1.3.6.1.4.1.41179.1.4";
+
+        /// <summary>
+        /// Category: Covered Entity as defined in HIPAA.
+        /// See DirectTrust CP section 3.2.2 Authentication of Organization Identity.
+        /// </summary>
+        public const string DTorgCE = "1.3.6.1.4.1.41179.2.1";
+
+        /// <summary>
+        /// Category: Business Associate (BA), as defined in HIPAA.
+        /// See DirectTrust CP section 3.2.2 Authentication of Organization Identity.
+        /// </summary>
+        public const string DTorgBA = "1.3.6.1.4.1.41179.2.2";
+
+        /// <summary>
+        /// Category: non-HIPAA Healthcare Entity (HE).
+        /// See DirectTrust CP section 3.2.2 Authentication of Organization Identity.
+        /// </summary>
+        public const string DTorgHE = "1.3.6.1.4.1.41179.2.3";
+
+        /// <summary>
+        /// Category: personal healthcare Direct message exchange.
+        /// See DirectTrust CP section 3.2.2 Authentication of Organization Identity.
+        /// </summary>
+        public const string DTorgPatient = "1.3.6.1.4.1.41179.2.4";
+    }
+}

--- a/csharp/common/common.csproj
+++ b/csharp/common/common.csproj
@@ -56,6 +56,10 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <HintPath>..\build\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -77,12 +81,16 @@
     <Compile Include="Certificates\AnchorBundle.cs" />
     <Compile Include="Certificates\AnchorMetadata.cs" />
     <Compile Include="Certificates\AnchorX509Certificate2.cs" />
+    <Compile Include="Certificates\AbstractBuilder.cs" />
+    <Compile Include="Certificates\CertificateRevocationListBuilder.cs" />
+    <Compile Include="Certificates\CertificateBuilder.cs" />
     <Compile Include="Certificates\CertificateCache.cs" />
     <Compile Include="Certificates\CertificateIndex.cs" />
     <Compile Include="Certificates\CertificateResolver.cs" />
     <Compile Include="Certificates\CertificateResolverCollection.cs" />
     <Compile Include="Certificates\CertificateStore.cs" />
     <Compile Include="Certificates\CryptoUtility.cs" />
+    <Compile Include="Certificates\DirectTrustCertificatePolicies.cs" />
     <Compile Include="Certificates\DnsCertResolver.cs" />
     <Compile Include="Certificates\Extensions.cs" />
     <Compile Include="Certificates\ICertificateResolver.cs" />
@@ -247,6 +255,9 @@
     <Compile Include="Web\WebDownloader.cs">
       <SubType>Component</SubType>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/csharp/common/packages.config
+++ b/csharp/common/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.8.1" targetFramework="net452" />
-  <package id="Pkcs11Interop.StrongName" version="3.3.0" targetFramework="net452" />
 </packages>

--- a/csharp/config/console/Command/TestCommands.cs
+++ b/csharp/config/console/Command/TestCommands.cs
@@ -3,8 +3,9 @@
  All rights reserved.
 
  Authors:
-    Umesh Madan     umeshma@microsoft.com
-  
+    Umesh Madan         umeshma@microsoft.com
+    Dávid Koronthály    koronthaly@hotmail.com
+
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
@@ -13,15 +14,16 @@ Neither the name of The Direct Project (directproject.org) nor the names of its 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  
 */
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-
 using Health.Direct.Common.Certificates;
 using Health.Direct.Common.Extensions;
 using Health.Direct.Config.Store;
 using Health.Direct.Config.Tools.Command;
+using Org.BouncyCastle.Asn1.X509;
 
 namespace Health.Direct.Config.Console.Command
 {
@@ -31,20 +33,132 @@ namespace Health.Direct.Config.Console.Command
     /// </summary>
     public class TestCommands : CommandsBase
     {
-        internal TestCommands(ConfigConsole console) : base(console)
+        public TestCommands(ConfigConsole console)
+            : base(console)
         {
         }
 
-        [Command(Name ="Test_Certs_Install",
-            Usage = "Install test certs into machine stores")]
+        /// <summary>
+        /// The old test certificates generated using 'makecert' command do not meet current Direct standard.
+        /// This is an example how to generate a full chain of certificates, including all required extensions.
+        /// </summary>
+        /// <param name="args">Directory to save certificate files to. Optional, defaults to current directory.</param>
+        [Command(Name = "Test_Certs_Create", Usage = "Creates test certificates.")]
+        public void TestCertsCreate(string[] args)
+        {
+            // Initialize the names.
+            var rootDomain = "hsgincubator.com";
+            var redmondDomain = $"redmond.{rootDomain}";
+            var nhindDomain = $"nhind.{rootDomain}";
+            var testEmailAddress = $"test@{nhindDomain}";
+            var testDomain = testEmailAddress.Replace('@', '.');
+
+            string path = args.GetOptionalValue(0, Path.Combine(Directory.GetCurrentDirectory(), "Certificates"));
+
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            // Create a self-signed certificate authority.
+            var rootCaBuilder = new CertificateBuilder(1)
+            {
+                SubjectDN = new X509Name($"CN={rootDomain}")
+            };
+            rootCaBuilder.SetSubjectAlternativeNameToDomain(rootDomain);
+            var rootCa = rootCaBuilder.Generate();
+            File.WriteAllBytes(Path.Combine(path, $"{rootDomain}.pfx"), rootCa.Export(X509ContentType.Pfx));
+            File.WriteAllBytes(Path.Combine(path, $"{rootDomain}.cer"), rootCa.Export(X509ContentType.Cert));
+
+            // Create valid organizational certificate.
+            var redmondValidCertBuilder = new CertificateBuilder(rootCa)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.cer"),
+                CrlDistributionPointUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.crl"),
+                SubjectDN = new X509Name($"CN={redmondDomain}")
+            };
+            redmondValidCertBuilder.SetSubjectAlternativeNameToDomain(redmondDomain);
+            var redmondValidCert = redmondValidCertBuilder.Generate();
+            File.WriteAllBytes(Path.Combine(path, $"{redmondDomain}-valid.pfx"), redmondValidCert.Export(X509ContentType.Pfx));
+            File.WriteAllBytes(Path.Combine(path, $"{redmondDomain}-valid.cer"), redmondValidCert.Export(X509ContentType.Cert));
+
+            // Create revoked organizational certificate.
+            var redmondRevokedCertBuilder = new CertificateBuilder(rootCa)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.cer"),
+                CrlDistributionPointUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.crl"),
+                SubjectDN = new X509Name($"CN={redmondDomain}")
+            };
+            redmondRevokedCertBuilder.SetSubjectAlternativeNameToDomain(redmondDomain);
+            var redmondRevokedCert = redmondRevokedCertBuilder.Generate();
+            File.WriteAllBytes(Path.Combine(path, $"{redmondDomain}-revoked.pfx"), redmondRevokedCert.Export(X509ContentType.Pfx));
+            File.WriteAllBytes(Path.Combine(path, $"{redmondDomain}-revoked.cer"), redmondRevokedCert.Export(X509ContentType.Cert));
+
+            // Create a certificate revocation list.
+            var rootCrlBuilder = new CertificateRevocationListBuilder(rootCa, 1)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.cer")
+            };
+            rootCrlBuilder.AddRevokedCertificate(redmondRevokedCert);
+            var rootCrl = rootCrlBuilder.Generate();
+            var rootCrlBytes = rootCrl.GetEncoded();
+            File.WriteAllBytes(Path.Combine(path, $"{rootDomain}.crl"), rootCrlBytes);
+
+            // Intermediate certificate authority.
+            var nhindCaBuilder = new CertificateBuilder(rootCa, 0)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.cer"),
+                CrlDistributionPointUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.crl"),
+                SubjectDN = new X509Name($"CN={nhindDomain}")
+            };
+            nhindCaBuilder.SetSubjectAlternativeNameToDomain(nhindDomain);
+            var nhindCa = nhindCaBuilder.Generate();
+            File.WriteAllBytes(Path.Combine(path, $"{nhindDomain}.pfx"), nhindCa.Export(X509ContentType.Pfx));
+            File.WriteAllBytes(Path.Combine(path, $"{nhindDomain}.cer"), nhindCa.Export(X509ContentType.Cert));
+
+            // Create valid address-bound certificate.
+            var testValidCertBuilder = new CertificateBuilder(nhindCa)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.cer"),
+                CrlDistributionPointUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.crl"),
+                SubjectDN = new X509Name($"CN={testEmailAddress}")
+            };
+            testValidCertBuilder.SetSubjectAlternativeNameToEmail(testEmailAddress);
+            var testValidCert = testValidCertBuilder.Generate();
+            File.WriteAllBytes(Path.Combine(path, $"{testDomain}-valid.pfx"), testValidCert.Export(X509ContentType.Pfx));
+            File.WriteAllBytes(Path.Combine(path, $"{testDomain}-valid.cer"), testValidCert.Export(X509ContentType.Cert));
+
+            // Create revoked address-bound certificate.
+            var testRevokedCertBuilder = new CertificateBuilder(nhindCa)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.cer"),
+                CrlDistributionPointUri = new Uri($"http://{rootDomain}/pki/{rootDomain}.crl"),
+                SubjectDN = new X509Name($"CN={testEmailAddress}")
+            };
+            testRevokedCertBuilder.SetSubjectAlternativeNameToEmail(testEmailAddress);
+            var testRevokedCert = testRevokedCertBuilder.Generate();
+            File.WriteAllBytes(Path.Combine(path, $"{testDomain}-revoked.pfx"), testRevokedCert.Export(X509ContentType.Pfx));
+            File.WriteAllBytes(Path.Combine(path, $"{testDomain}-revoked.cer"), testRevokedCert.Export(X509ContentType.Cert));
+
+            // Create a certificate revocation list.
+            var nhindCrlBuilder = new CertificateRevocationListBuilder(nhindCa, 1)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{rootDomain}/pki/{nhindDomain}.cer")
+            };
+            nhindCrlBuilder.AddRevokedCertificate(redmondRevokedCert);
+            var nhindCrl = nhindCrlBuilder.Generate();
+            var nhindCrlBytes = nhindCrl.GetEncoded();
+            File.WriteAllBytes(Path.Combine(path, $"{nhindDomain}.crl"), nhindCrlBytes);
+        }
+
+        [Command(Name = "Test_Certs_Install", Usage = "Install test certs into machine stores")]
         public void TestCertsInstall(string[] args)
         {
             string path = args.GetOptionalValue(0, Directory.GetCurrentDirectory());
             EnsureStandardMachineStores(path);
         }
 
-        [Command(Name = "Reset_Stores",
-            Usage = "Remove certs in all Direct Project machine stores")]
+        [Command(Name = "Reset_Stores", Usage = "Remove certs in all Direct Project machine stores")]
         public void ResetStores(string[] args)
         {
             SystemX509Store store;
@@ -83,31 +197,31 @@ namespace Health.Direct.Config.Console.Command
             string path = args.GetOptionalValue(0, Directory.GetCurrentDirectory());
             EnsureStandardCertsInService(path);
         }
-        
-        [Command(Name = "Test_Stores_Ensure", Usage="Ensures all standard machine stores are created")]
+
+        [Command(Name = "Test_Stores_Ensure", Usage = "Ensures all standard machine stores are created")]
         public void EnsureMachineStores(string[] args)
         {
-            SystemX509Store store = null;
-
-            using (store = SystemX509Store.OpenPrivateEdit())
+            using (SystemX509Store.OpenPrivateEdit())
             {
                 WriteLine("Created Private Store");
             }
-            using (store = SystemX509Store.OpenExternalEdit())
+
+            using (SystemX509Store.OpenExternalEdit())
             {
                 WriteLine("Created Public Store");
             }
-            using (store = SystemX509Store.OpenAnchorEdit())
+
+            using (SystemX509Store.OpenAnchorEdit())
             {
                 WriteLine("Created Anchor Store");
             }
         }
-        
+
         static string MakeCertificatesPath(string basePath, string agentFolder)
         {
             return Path.Combine(basePath, Path.Combine("Certificates", agentFolder));
         }
-                
+
         void EnsureStandardMachineStores(string path)
         {
             SystemX509Store.CreateAll();
@@ -157,19 +271,30 @@ namespace Health.Direct.Config.Console.Command
             }
 
             MemoryX509Store certStore = new MemoryX509Store();
-            string[] files = Directory.GetFiles(folderPath);
-            if (ArrayExtensions.IsNullOrEmpty(files))
-            {
-                throw new ArgumentException("Empty directory");
-            }
 
-            CertificateCommands certcmd = GetCommand<CertificateCommands>();
-            foreach(string file in files)
+            try
             {
-                certcmd.LoadCerts(certStore, file, "passw0rd!", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
-            }
+                string[] files = Directory.GetFiles(folderPath);
 
-            return certStore;
+                if (files.IsNullOrEmpty())
+                {
+                    throw new ArgumentException("Empty directory");
+                }
+
+                CertificateCommands certcmd = GetCommand<CertificateCommands>();
+
+                foreach (string file in files)
+                {
+                    certcmd.LoadCerts(certStore, file, "passw0rd!", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                }
+
+                return certStore;
+            }
+            catch
+            {
+                certStore.Dispose();
+                throw;
+            }
         }
 
         void InstallCerts(IX509CertificateStore store, IEnumerable<X509Certificate2> certs)
@@ -183,7 +308,7 @@ namespace Health.Direct.Config.Console.Command
                 }
             }
         }
-        
+
         void EnsureStandardCertsInService(string basePath)
         {
             WriteLine("Installing Private Certs in config service");
@@ -194,7 +319,7 @@ namespace Health.Direct.Config.Console.Command
             CertificateCommands certcmds = GetCommand<CertificateCommands>();
             certcmds.PushCerts(LoadCerts(redmondCertsPath, "Private"), true, EntityStatus.Enabled);
             certcmds.PushCerts(LoadCerts(nhindCertsPath, "Private"), true, EntityStatus.Enabled);
-            
+
             WriteLine("Installing Anchors in config service");
 
             AnchorCommands anchorcmds = GetCommand<AnchorCommands>();
@@ -202,6 +327,6 @@ namespace Health.Direct.Config.Console.Command
             anchorcmds.PushCerts("redmond.hsgincubator.com", LoadCerts(redmondCertsPath, "OutgoingAnchors"), true, EntityStatus.Enabled);
             anchorcmds.PushCerts("nhind.hsgincubator.com", LoadCerts(nhindCertsPath, "IncomingAnchors"), true, EntityStatus.Enabled);
             anchorcmds.PushCerts("nhind.hsgincubator.com", LoadCerts(nhindCertsPath, "OutgoingAnchors"), true, EntityStatus.Enabled);
-        }        
+        }
     }
 }

--- a/csharp/hsmCryptographer/HsmCryptographer.csproj
+++ b/csharp/hsmCryptographer/HsmCryptographer.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\build\packages\BouncyCastle.Crypto.dll.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <HintPath>..\build\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Pkcs11Interop.StrongName, Version=3.3.0.0, Culture=neutral, PublicKeyToken=c10e9c2d8c006d2a, processorArchitecture=MSIL">

--- a/csharp/unittests/common/Certificates/CertificateBuilderFacts.cs
+++ b/csharp/unittests/common/Certificates/CertificateBuilderFacts.cs
@@ -1,0 +1,90 @@
+﻿/* 
+ Copyright (c) 2017, Direct Project
+ All rights reserved.
+
+ Authors:
+    Dávid Koronthály    koronthaly@hotmail.com
+  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+Neither the name of The Direct Project (directproject.org) nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Health.Direct.Common.Certificates;
+using Org.BouncyCastle.Asn1.X509;
+using Xunit;
+
+namespace Health.Direct.Common.Tests.Certificates
+{
+    public class CertificateBuilderFacts
+    {
+        private const string Domain = "nhind.hsgincubator.com";
+        private X509Certificate2 _rootCA;
+
+
+        [Fact]
+        public void IssueSimpleCertificate()
+        {
+            var emailAddress = $"test@{Domain}";
+
+            var issuer = CreateCertificateAuthority(Domain);
+            var certificate = CreateAddressBoundCertificate(issuer, emailAddress);
+
+            Assert.False(certificate.IsCertificateAuthority());
+            Assert.True(certificate.HasValidDateRange());
+            Assert.True(certificate.HasPrivateKey);
+            Assert.Equal(certificate.IssuerName.ToString(), issuer.SubjectName.ToString());
+            Assert.True(certificate.MatchName(emailAddress));
+        }
+
+        [Fact]
+        public void IssueCertificateAuthority()
+        {
+            var certificate = CreateCertificateAuthority(Domain);
+
+            Assert.True(certificate.IsCertificateAuthority());
+            Assert.True(certificate.HasValidDateRange());
+            Assert.True(certificate.HasPrivateKey);
+            Assert.Equal(certificate.IssuerName.ToString(), certificate.SubjectName.ToString());
+            Assert.True(certificate.MatchName(Domain));
+        }
+
+        private X509Certificate2 CreateCertificateAuthority(string domain)
+        {
+            if (_rootCA == null)
+            {
+                var builder = new CertificateBuilder(1)
+                {
+                    SubjectDN = new X509Name($"CN={domain}")
+                };
+
+                builder.SetSubjectAlternativeNameToDomain(domain);
+                builder.Policies.Add(DirectTrustCertificatePolicies.DTorgCPVersions);
+                _rootCA = builder.Generate();
+            }
+
+            return _rootCA;
+        }
+
+        private X509Certificate2 CreateAddressBoundCertificate(X509Certificate2 issuer, string emailAddress)
+        {
+            var domain = issuer.GetNameInfo(X509NameType.DnsName, false);
+
+            var builder = new CertificateBuilder(issuer)
+            {
+                AuthorityInformationAccessUri = new Uri($"http://{domain}/pki/{domain}.cer"),
+                CrlDistributionPointUri = new Uri($"http://{domain}/pki/{domain}.crl"),
+                SubjectDN = new X509Name($"CN={emailAddress}")
+            };
+
+            builder.SetSubjectAlternativeNameToEmail(emailAddress);
+            builder.Policies.Add(DirectTrustCertificatePolicies.DTorgCPVersions);
+            return builder.Generate();
+        }
+    }
+}

--- a/csharp/unittests/common/common.tests.csproj
+++ b/csharp/unittests/common/common.tests.csproj
@@ -58,6 +58,10 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <HintPath>..\..\build\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Security.Cryptography, Version=1.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\external\codeplex\Security.Cryptography.dll</HintPath>
@@ -90,6 +94,7 @@
     <Compile Include="Caching\DnsClientWithCacheFacts.cs" />
     <Compile Include="Caching\DnsResponseCacheFacts.cs" />
     <Compile Include="Caching\DnsResponseToBinExample.cs" />
+    <Compile Include="Certificates\CertificateBuilderFacts.cs" />
     <Compile Include="Certificates\CertificateFacts.cs" />
     <Compile Include="Certificates\CertificateResolverBasic.cs" />
     <Compile Include="Certificates\CertificateResolverFacts.cs" />

--- a/csharp/unittests/common/packages.config
+++ b/csharp/unittests/common/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.1" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
@JoeShook - the old makecert generated certificates have many issues. To replace them, I have implemented a certificate builder using Bouncy Castle. There is a new test command that demonstrates how to build the whole chain, including variants.

Looking for a feedback on the proper shape of Direct certificates - trying to establish best practice by having a public example available for everyone to comment on and/or improve.