### PR TITLE
Intermediate Certificate Validation Windows 2012+ fix

### DIFF
--- a/csharp/agent/Certificates/TrustChainValidator.cs
+++ b/csharp/agent/Certificates/TrustChainValidator.cs
@@ -291,10 +291,12 @@ namespace Health.Direct.Agent.Certificates
             return false;
         }
 
+        // X509ChainEngine, which is used for CRL validation, requires Windows 2012 to run due to required changes in the CERT_CHAIN_ENGINE_CONFIG structure.
+        // For more information on version numbers, see https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832.aspx
         private static bool IsNewerThanWin2008R2()
         {
             return Environment.OSVersion.Version.Major > 6 ||  
-                   (Environment.OSVersion.Version.Major >= 6 && Environment.OSVersion.Version.Minor > 2);
+                   (Environment.OSVersion.Version.Major >= 6 && Environment.OSVersion.Version.Minor >= 2);
         }
 
         private bool ChainElementHasProblems(X509ChainElement chainElement)

--- a/csharp/agent/Certificates/X509ChainEngine.cs
+++ b/csharp/agent/Certificates/X509ChainEngine.cs
@@ -88,7 +88,8 @@ namespace Health.Direct.Agent.Certificates
                 cbSize = (uint)sizeof(NativeMethods.CERT_CHAIN_ENGINE_CONFIG),
                 dwFlags = NativeMethods.CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE | NativeMethods.CERT_CHAIN_ENABLE_SHARE_STORE,
                 // Need to retrieve underlying IntPtr. The struct cannot contain a Safehandle field as we need to be able to use sizeof()
-                hExclusiveRoot = this.safeCertStoreHandle.DangerousGetHandle()
+                hExclusiveRoot = this.safeCertStoreHandle.DangerousGetHandle(),
+                dwExclusiveFlags = NativeMethods.CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG
             };
 
             if (!NativeMethods.CertCreateCertificateChainEngine(new IntPtr(&certChainEngineConfig), out this.safeChainEngineHandle))

--- a/csharp/unittests/agent/TrustChainTests.cs
+++ b/csharp/unittests/agent/TrustChainTests.cs
@@ -45,8 +45,21 @@ namespace Health.Direct.Agent.Tests
         [Fact]
         public void TestValidTrustChain()
         {
+            this.ValidateCertChainWithAnchor(m_trustedAnchors);
+        }
+
+
+        [Fact]
+        public void TestValidTrustedChainIntermediateAnchor()
+        {
+            var trustedIntermediate = m_resolver.GetCertificatesForDomain("inter1.xyz");
+            this.ValidateCertChainWithAnchor(trustedIntermediate);
+        }
+
+        private void ValidateCertChainWithAnchor(X509Certificate2Collection trustedIntermediate)
+        {
             Assert.True(!m_endCerts.IsNullOrEmpty());
-            Assert.True(!m_trustedAnchors.IsNullOrEmpty());
+            Assert.True(!trustedIntermediate.IsNullOrEmpty());
 
             //
             // Ok, verify certs..
@@ -55,7 +68,7 @@ namespace Health.Direct.Agent.Tests
             {
                 X509Certificate2Collection issuers = m_validator.ResolveIntermediateIssuers(cert);
                 Assert.True(!issuers.IsNullOrEmpty() && issuers.Count == 3);
-                Assert.True(m_validator.IsTrustedCertificate(cert, m_trustedAnchors));
+                Assert.True(m_validator.IsTrustedCertificate(cert, trustedIntermediate));
             }
         }
 


### PR DESCRIPTION
Fix for a problem with validating certificates in which the intermediate certificate, not the root, was used as an anchor