### PR TITLE
XD Metadata Fixes

### DIFF
--- a/csharp/xd/Association.cs
+++ b/csharp/xd/Association.cs
@@ -19,6 +19,8 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 
+using Health.Direct.Xd.Common.ebXml;
+
 namespace Health.Direct.Xd
 {
     /// <summary>
@@ -49,7 +51,7 @@ namespace Health.Direct.Xd
         /// </summary>
         public static Association OriginalDocumentAssociation(string submissionSetId, string documentEntryId)
         {
-            return new Association("HasMember", submissionSetId, documentEntryId,
+            return new Association(AssociationKind.HasMember, submissionSetId, documentEntryId,
                 new Slot(XDMetadataStandard.Slots.SubmissionSetStatus, "Original"));
         }
     }

--- a/csharp/xd/CodedValueClassification.cs
+++ b/csharp/xd/CodedValueClassification.cs
@@ -94,9 +94,9 @@ namespace Health.Direct.Xd
 
         private void Initialize(string codingScheme, string label)
         {
-            this.Add(new Name(label),
-                     new Slot(XDMetadataStandard.Slots.CodingScheme, codingScheme));
-        }
+             this.Add(new Slot(XDMetadataStandard.Slots.CodingScheme, codingScheme),
+                     new Name(label));
+       }
 
     }
 }

--- a/csharp/xd/Extensions.cs
+++ b/csharp/xd/Extensions.cs
@@ -16,6 +16,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace Health.Direct.Xd
 {
@@ -77,5 +78,23 @@ namespace Health.Direct.Xd
             if (strings == null || strings.Count() == 0) return null;
             return strings.Skip(1).Aggregate(strings.First(), (a, s) => a + sep + s);
         }
-    }
+ 
+        /// <summary>
+        /// Sets the namespace of this element and all child elements to the given <see cref="XNamespace"/>
+        /// when not already set.
+        /// </summary>
+        /// <param name="el">The root element at which to start setting namespaces.</param>
+        /// <param name="ns">The namespace to use.</param>
+        public static void SetDefaultNamespace(this XElement el, XNamespace ns)
+        {
+            if (string.IsNullOrEmpty(el.Name.NamespaceName))
+            {
+                el.Name = ns + el.Name.LocalName;
+            }
+            foreach (var e in el.Elements())
+            {
+                e.SetDefaultNamespace(ns);
+            }
+        }
+   }
 }

--- a/csharp/xd/StringWriterWithEncoding.cs
+++ b/csharp/xd/StringWriterWithEncoding.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Health.Direct.Xd
+{
+	/// <summary>
+	/// An implementation of <see cref="StringWriter"/> that allows the output encoding to be specified.
+	/// </summary>
+	public class StringWriterWithEncoding : StringWriter
+	{
+		/// <summary>
+		/// Gets the <see cref="Encoding"/> in which the output is written.
+		/// </summary>
+		public override Encoding Encoding { get; }
+
+		/// <summary>
+		/// Creates a new <see cref="StringWriter"/> that uses the given <see cref="Encoding"/> for its output.
+		/// </summary>
+		/// <param name="encoding">The <see cref="Encoding"/> in which the output is written.</param>
+		public StringWriterWithEncoding(Encoding encoding) : this(new StringBuilder(), CultureInfo.CurrentCulture, encoding)
+		{
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="StringWriter"/> that uses the given <see cref="Encoding"/> for its output.
+		/// </summary>
+		/// <param name="formatProvider">The object that controls formatting.</param>
+		/// <param name="encoding">The <see cref="Encoding"/> in which the output is written.</param>
+		public StringWriterWithEncoding(IFormatProvider formatProvider, Encoding encoding) : this(new StringBuilder(), formatProvider, encoding)
+		{
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="StringWriter"/> that uses the given <see cref="Encoding"/> for its output.
+		/// </summary>
+		/// <param name="sb">A <see cref="StringBuilder"/> to write to.</param>
+		/// <param name="encoding">The <see cref="Encoding"/> in which the output is written.</param>
+		public StringWriterWithEncoding(StringBuilder sb, Encoding encoding) : this(sb, CultureInfo.CurrentCulture, encoding)
+		{
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="StringWriter"/> that uses the given <see cref="Encoding"/> for its output.
+		/// </summary>
+		/// <param name="sb">A <see cref="StringBuilder"/> to write to.</param>
+		/// <param name="formatProvider">The object that controls formatting.</param>
+		/// <param name="encoding">The <see cref="Encoding"/> in which the output is written.</param>
+		public StringWriterWithEncoding(StringBuilder sb, IFormatProvider formatProvider, Encoding encoding) : base(sb, formatProvider)
+		{
+			Encoding = encoding;
+		}
+	}
+}

--- a/csharp/xd/XDMetadataGenerator.cs
+++ b/csharp/xd/XDMetadataGenerator.cs
@@ -108,18 +108,18 @@ namespace Health.Direct.Xd
         {
             string packageId = MakeUUID();
             XElement packageMetadata = new XElement(XDMetadataStandard.Elts.SubmissionSet,
-                                                    new XAttribute(XDMetadataStandard.Attrs.Id, packageId),
-                                                    new Classification(XDMetadataStandard.UUIDs.SubmissionSetClassification, packageId));
+                                                    new XAttribute(XDMetadataStandard.Attrs.Id, packageId));
 
             List<Pair<Object, Func<XObject>>> specs = 
             new List<Pair<Object, Func<XObject>>>
             {   
-                // XSD requires the following order: name, description, slots, classifications, external identifiers
-                Map(dp.Title,             () => new Name(dp.Title)),
-                Map(dp.Comments,          () => new Description(dp.Comments)),
-                Map(dp.Author,            () => new MultiSlotClassification(XDMetadataStandard.UUIDs.SubmissionSetAuthor, "", packageId, AuthorSlots(dp.Author))),
+                // XSD requires the following order: slots, name, description, classifications, external identifiers
                 Map(dp.IntendedRecipients,() => new Slot(XDMetadataStandard.Slots.IntendedRecipient, dp.IntendedRecipients.Select(r => r.ToXONXCNXTN()))),
                 Map(dp.SubmissionTime,    () => new Slot(XDMetadataStandard.Slots.SubmissionTime, dp.SubmissionTime.ToHL7Date())),
+                Map(dp.Title,             () => new Name(dp.Title)),
+                Map(dp.Comments,          () => new Description(dp.Comments)),
+                Map(packageId,            () => new Classification(XDMetadataStandard.UUIDs.SubmissionSetClassification, packageId)),
+                Map(dp.Author,            () => new MultiSlotClassification(XDMetadataStandard.UUIDs.SubmissionSetAuthor, "", packageId, AuthorSlots(dp.Author))),
                 Map(dp.ContentTypeCode,   () => new CodedValueClassification(XDAttribute.ContentTypeCode, packageId, dp.ContentTypeCode)),
                 Map(dp.PatientId,         () => new ExternalIdentifier(XDMetadataStandard.UUIDs.SubmissionSetPatientId, dp.PatientId.ToEscapedCx(), "XDSSubmissionSet.patientId")),
                 Map(dp.SourceId,          () => new ExternalIdentifier(XDMetadataStandard.UUIDs.SubmissionSetSourceId, dp.SourceId, "XDSSubmissionSet.sourceId")),

--- a/csharp/xd/XDMetadataGenerator.cs
+++ b/csharp/xd/XDMetadataGenerator.cs
@@ -161,10 +161,7 @@ namespace Health.Direct.Xd
             new List<Pair<Object, Func<XObject>>>
             {
                 Map(dm.MediaType,         () => new XAttribute(XDMetadataStandard.Attrs.MimeType, dm.MediaType) ),
-                // XSD requires the following order: name, description, slots, classifications, external identifiers
-                Map(dm.Title,             () => new Name(dm.Title) ),
-                Map(dm.Comments,          () => new Description(dm.Comments)),
-                Map(dm.Author,            () => new MultiSlotClassification(XDMetadataStandard.UUIDs.DocumentAuthor, "", documentName, AuthorSlots(dm.Author))),
+                // XSD requires the following order: slots, name, description, classifications, external identifiers
                 Map(dm.CreatedOn,         () => new Slot(XDMetadataStandard.Slots.CreationTime, dm.CreatedOn.ToHL7Date())),
                 Map(dm.Hash,              () => new Slot(XDMetadataStandard.Slots.Hash, dm.Hash)),
                 Map(dm.LanguageCode,      () => new Slot(XDMetadataStandard.Slots.LanguageCode, dm.LanguageCode)),
@@ -175,6 +172,9 @@ namespace Health.Direct.Xd
                 Map(dm.SourcePtId,        () => new Slot(XDMetadataStandard.Slots.SourcePatientID, dm.SourcePtId.ToEscapedCx()) ),
                 Map(dm.Patient,           () => new Slot(XDMetadataStandard.Slots.SourcePatientInfo, dm.Patient.ToSourcePatientInfoValues(dm.SourcePtId))),
                 Map(dm.Uri,               () => new Slot(XDMetadataStandard.Slots.Uri, UriValues(dm.Uri))),
+                Map(dm.Title,             () => new Name(dm.Title) ),
+                Map(dm.Comments,          () => new Description(dm.Comments)),
+                Map(dm.Author,            () => new MultiSlotClassification(XDMetadataStandard.UUIDs.DocumentAuthor, "", documentName, AuthorSlots(dm.Author))),
                 Map(dm.Class,             () => new CodedValueClassification(XDAttribute.ClassCode, documentName, dm.Class)),
                 Map(dm.Confidentiality,   () => new CodedValueClassification(XDAttribute.ConfidentialityCode, documentName, dm.Confidentiality)),
                 Map(dm.EventCodes,        () => EventCodeClassifications(dm.EventCodes, documentName)),

--- a/csharp/xd/XDMetadataGenerator.cs
+++ b/csharp/xd/XDMetadataGenerator.cs
@@ -96,6 +96,8 @@ namespace Health.Direct.Xd
                 packageList.Add(doc);
                 packageList.Add(assoc);
             }
+            submitObjectsRequest.SetDefaultNamespace(XDMetadataStandard.Ns.Rim);
+
             return submitObjectsRequest;
         }
 

--- a/csharp/xd/XDMetadataGenerator.cs
+++ b/csharp/xd/XDMetadataGenerator.cs
@@ -230,6 +230,8 @@ namespace Health.Direct.Xd
                 yield return new Slot(XDMetadataStandard.Slots.AuthorInstitutions, a.Institutions.Select(i => i.ToXON()));
             if (a.Person != null)
                 yield return new Slot(XDMetadataStandard.Slots.AuthorPerson, a.Person.ToXCN());
+            if (a.TelecomAddress.Email != null)
+                yield return new Slot(XDMetadataStandard.Slots.AuthorTelecommunication, a.TelecomAddress.ToXTN());
         }
 
         /// <summary>

--- a/csharp/xd/XDMetadataGenerator.cs
+++ b/csharp/xd/XDMetadataGenerator.cs
@@ -222,11 +222,11 @@ namespace Health.Direct.Xd
         {
             if (a == null)
                 yield break;
-            if (a.Specialities != null)
+            if (a.Specialities != null && a.Specialities.Any())
                 yield return new Slot(XDMetadataStandard.Slots.AuthorSpecialities, a.Specialities);
-            if (a.Roles != null)
+            if (a.Roles != null && a.Roles.Any())
                 yield return new Slot(XDMetadataStandard.Slots.AuthorRoles, a.Roles);
-            if (a.Institutions != null)
+            if (a.Institutions != null && a.Institutions.Any())
                 yield return new Slot(XDMetadataStandard.Slots.AuthorInstitutions, a.Institutions.Select(i => i.ToXON()));
             if (a.Person != null)
                 yield return new Slot(XDMetadataStandard.Slots.AuthorPerson, a.Person.ToXCN());

--- a/csharp/xd/XDMetadataStandard.cs
+++ b/csharp/xd/XDMetadataStandard.cs
@@ -344,6 +344,10 @@ namespace Health.Direct.Xd
             /// </summary>
             public const string AuthorSpecialities = "authorSpecialty";
 
+            /// The slot name for authorTelecommunication
+            /// </summary>
+            public const string AuthorTelecommunication = "authorTelecommunication";
+
             /// <summary>
             /// The slot name for hash
             /// </summary>

--- a/csharp/xd/xd.csproj
+++ b/csharp/xd/xd.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Name.cs" />
     <Compile Include="ExternalIdentifier.cs" />
     <Compile Include="Slot.cs" />
+    <Compile Include="StringWriterWithEncoding.cs" />
     <Compile Include="XdError.cs" />
     <Compile Include="XDMetadataConsumer.cs" />
     <Compile Include="XdMetadataException.cs" />

--- a/csharp/xd/xd.csproj
+++ b/csharp/xd/xd.csproj
@@ -88,6 +88,10 @@
       <Project>{87A47BBF-C056-43C8-8C4A-34D25A63D1F9}</Project>
       <Name>common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\xd.common\xd.common.csproj">
+      <Project>{25dddde7-3ba6-4e66-8870-a95abdf0549e}</Project>
+      <Name>xd.common</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">


### PR DESCRIPTION
Closes #281.

**After the root element, the namespace was being set to empty.**

    <lcm:SubmitObjectsRequest xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">
      <RegistryObjectList xmlns="">
      ...

Note the `xmlns=""` on the RegistryObjectList. Just a thing with how the XML library handles namespaces -- default is no namespace (i.e. empty), not the namespace of the parent node.

**Ability to set text encoding on the XML file.**

This requirement came from one of our partners; they refused to process with the default encoding of utf-16 (they required utf-8). utf-16 is still the default so as to avoid a breaking change, but added something that allows the encoding to be set.

**AuthorTelecommunication slot type missing.**

It's classified as an extension to the standard, so perhaps this should go somewhere else?

**Fixed element order.**

In `ExtrinsicObject`, `CodedValueClassification`, and `RegistryPackage`. Set these to match the element order as defined by the XSD.

**Use a URN for OriginalDocumentAssociation.AssociationKind**

Spec calls for the full URN syntax here; pulled it in from `xd.common`.

**Null checks on optional slots.**

There were a few places that weren't checking for nulls returned by `SlotValues` even on optional slots. Added in some checks for specific things we were hitting, but this probably isn't exhaustive. I'd prefer this return empty instead of null, but that might be a breaking change, 