### PR TITLE
make extension lookup for finding XDM messages case-insensitive

### DIFF
--- a/java/xd-common/src/main/java/org/nhindirect/xd/common/type/DirectDocumentType.java
+++ b/java/xd-common/src/main/java/org/nhindirect/xd/common/type/DirectDocumentType.java
@@ -119,7 +119,7 @@ public enum DirectDocumentType
         public boolean matches(String data, String contentType, String fileName)
         {
             // FIXME: Bad assumption
-            return StringUtils.contains(fileName, ".zip");
+            return StringUtils.containsIgnoreCase(fileName, ".zip");
         }  
     },
     PDF(null, MimeType.APPLICATION_PDF),


### PR DESCRIPTION
resolves issues where vendors are sending non-lowercase file extensions